### PR TITLE
Update deps.compile mix command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ mix.exs
 
 Fetch and compile the dependency
 
-```mix do deps.get, compile```
+```mix do deps.get, deps.compile```
 
 Configure ExAdmin:
 


### PR DESCRIPTION
I replaced `compile` with `deps.compile` in the README. This seemed to run both the `deps.get` and then `deps.compile` whereas simply running the original `mix do deps.get, compile` never ran the compile command and caused the issue in #14 