### PR TITLE
fix unformatted validation error message problem when used with Ecto

### DIFF
--- a/lib/ex_admin/form.ex
+++ b/lib/ex_admin/form.ex
@@ -1225,6 +1225,7 @@ defmodule ExAdmin.Form do
   def error_messages({:too_short, min}), do: "must be longer than #{min - 1}"
   def error_messages({:must_match, field}), do: "must match #{humanize field}"
   def error_messages(:format), do: "has incorrect format"
+  def error_messages({msg, opts}) when is_binary(msg), do: String.replace(msg, "%{count}", Integer.to_string(opts[:count]))
   def error_messages(other) when is_binary(other), do: other
   def error_messages(other), do: "error: #{inspect other}"
 end


### PR DESCRIPTION
If we use ex_admin with Ecto validate functions (e.g. validate_length), we see error messages like below:
`{"should be at most %{count} characters", 8}`

Placeholder is always '%{count}', so I think we can avoid this problem by this fix.

You can check discussions about this below:
https://github.com/elixir-lang/ecto/issues/512
https://github.com/elixir-lang/ecto/issues/738
