### PR TITLE
Check if /tmp exists, otherwise use System.tmp_dir

### DIFF
--- a/lib/ex_admin/register.ex
+++ b/lib/ex_admin/register.ex
@@ -40,7 +40,11 @@ defmodule ExAdmin.Register do
 
   """
 
-  @filename "/tmp/ex_admin_registered" 
+  if File.dir?("/tmp") do
+    @filename "/tmp/ex_admin_registered"
+  else
+    @filename System.tmp_dir <> "/ex_admin_registered"
+  end
 
   import ExAdmin.Utils
 


### PR DESCRIPTION
This fixes the /tmp file not being available on Windows. It uses the System.tmp_dir path where /tmp is not available.