### PR TITLE
fix(ExAdmin): don't convert id to integer

### DIFF
--- a/lib/ex_admin/breadcrumb.ex
+++ b/lib/ex_admin/breadcrumb.ex
@@ -40,9 +40,8 @@ defmodule ExAdmin.BreadCrumb do
   end
   defp get_breadcrumbs(_conn, _resource, _, _, _), do: []
 
-  defp get_name(_id, name) when is_binary(name), do: name
-  defp get_name(_id, name) when is_integer(name), do: Integer.to_string(name)
-  defp get_name(id, _), do: Integer.to_string(id)
+  defp get_name(_id, name) when not is_nil(name), do: to_string(name)
+  defp get_name(id, _), do: to_string(id)
 
   defp get_label(defn, name) do
     case Map.get defn, :menu do

--- a/lib/ex_admin/ex_admin.ex
+++ b/lib/ex_admin/ex_admin.ex
@@ -174,7 +174,6 @@ defmodule ExAdmin do
     case Utils.action_name(conn) do
       :show -> 
         id = Map.get(params, "id")
-        |> String.to_integer
         div(".action_items") do
           for action <- [:edit, :new, :delete], 
             do: action_button(conn, defn, singular, :show, action, actions, id)


### PR DESCRIPTION
If a UUID was used as the primary key, the show action would fail with:

 > ** (exit) an exception was raised:
 > ** (ArgumentError) argument error
 > :erlang.binary_to_integer("f7257870-bb73-4d88-b849-6aefd16ba986")
 > lib/ex_admin/ex_admin.ex:177: ExAdmin.default_resource_title_actions/2
 > lib/ex_admin/view_helpers.ex:88: ExAdmin.ViewHelpers.title_bar_right/1
 > lib/ex_admin/view_helpers.ex:19: ExAdmin.ViewHelpers.title_bar/2
 > web/templates/layout/admin.html.eex:30: ExAdmin.LayoutView."admin.html"/1

Since the id is converted to a string again in
`ExAdmin.Utils.get_route_path/3)` this conversation does not seem to be
required for integer ids.