### PR TITLE
feat(ExAdmin.Register): allow changesets to be specified

### DIFF
--- a/lib/ex_admin/register.ex
+++ b/lib/ex_admin/register.ex
@@ -37,6 +37,7 @@ defmodule ExAdmin.Register do
   * `collection_action` - Add a custom action for collection based requests
   * `clear_action_items!` - Remove the action item buttons
   * `action_item` - Defines custom action items
+  * `changesets` - Defines custom changeset functions
 
   """
 
@@ -89,6 +90,7 @@ defmodule ExAdmin.Register do
       Module.put_attribute(__MODULE__, :module, module)
       Module.put_attribute(__MODULE__, :query, nil)
       Module.put_attribute(__MODULE__, :selectable_column, nil)
+      Module.put_attribute(__MODULE__, :changesets, [])
 
       alias unquote(mod)
       import Ecto.Query
@@ -162,6 +164,7 @@ defmodule ExAdmin.Register do
                 index_filters: Module.get_attribute(__MODULE__, :index_filters),
                 selectable_column: Module.get_attribute(__MODULE__, :selectable_column), 
                 batch_actions: Module.get_attribute(__MODULE__, :batch_actions), 
+                changesets: Module.get_attribute(__MODULE__, :changesets), 
                 plugs: plugs 
 
 
@@ -265,6 +268,32 @@ defmodule ExAdmin.Register do
   defmacro before_filter(name, opts) do
     quote location: :keep do
       Module.put_attribute(__MODULE__, :controller_filters, {:before_filter, {unquote(name), unquote(opts)}})
+    end
+  end
+
+  @doc """
+  Override the changeset function for `update` and `create` actions.
+  By default, `changeset/2` for the resource will be used.
+
+  ## Examples
+
+  The following example illustrates how to add a sync action that will
+  be run before the index page is loaded.
+
+  changeset create: &__MODULE__.create_changeset/2,
+            update: &__MODULE__.update_changeset/2
+
+  def create_changeset(model, params) do
+    Ecto.Changeset.cast(model, params, ~w(name password), ~w(age))
+  end
+
+  def update_changeset(model, params) do
+    Ecto.Changeset.cast(model, params, ~w(name), ~w(age password))
+  end
+  """
+  defmacro changesets(opts) do
+    quote location: :keep do
+      Module.put_attribute(__MODULE__, :changesets, unquote(opts))
     end
   end
 

--- a/lib/ex_admin/repo.ex
+++ b/lib/ex_admin/repo.ex
@@ -8,18 +8,18 @@ defmodule ExAdmin.Repo do
 
   def repo, do: Application.get_env(:ex_admin, :repo)
 
-  def changeset(resource, nil), do: changeset(resource, %{})
-  def changeset(resource, params) do
+  def changeset(fun, resource, nil), do: changeset(fun, resource, %{})
+  def changeset(fun, resource, params) do
     %ExAdmin.Changeset{}
-    |> changeset(resource, params)
+    |> changeset(fun, resource, params)
     |> changeset_attributes_for(resource, params)
     |> changeset_collection(resource, params)
   end
 
-  def changeset(%Changeset{} = changeset, resource, nil), 
-    do: changeset(changeset, resource, %{})
-  def changeset(%Changeset{} = changeset, resource, params) do
-    cs = resource.__struct__.changeset(resource, params)
+  def changeset(%Changeset{} = changeset, fun, resource, nil), 
+    do: changeset(changeset, fun, resource, %{})
+  def changeset(%Changeset{} = changeset, fun, resource, params) do
+    cs = fun.(resource, params)
     Changeset.update(changeset, valid?: cs.valid?, changeset: cs, errors: cs.errors)
   end
 


### PR DESCRIPTION
The changeset functions to be used on create and update can now be
specified. If not specified then `module.changeset/2` will be used by
default.