### PR TITLE
fix(ExAdmin): compiler warnings

### DIFF
--- a/lib/ex_admin/form.ex
+++ b/lib/ex_admin/form.ex
@@ -832,17 +832,17 @@ defmodule ExAdmin.Form do
     build_errors(errors)
   end
 
-  def build_control(Ecto.DateTime, resource, opts, model_name, field_name, ext_name, errors) do
+  def build_control(Ecto.DateTime, resource, opts, model_name, field_name, _ext_name, errors) do
     %{name: model_name, model: resource, id: model_name}
     |> datetime_select(field_name, Map.get(opts, :options, []))
     build_errors(errors)
   end
-  def build_control(Ecto.Date, resource, opts, model_name, field_name, ext_name, errors) do
+  def build_control(Ecto.Date, resource, opts, model_name, field_name, _ext_name, errors) do
     %{name: model_name, model: resource, id: model_name}
     |> date_select(field_name, Map.get(opts, :options, []))
     build_errors(errors)
   end
-  def build_control(Ecto.Time, resource, opts, model_name, field_name, ext_name, errors) do
+  def build_control(Ecto.Time, resource, opts, model_name, field_name, _ext_name, errors) do
     %{name: model_name, model: resource, id: model_name}
     |> time_select(field_name, Map.get(opts, :options, []))
     build_errors(errors)
@@ -1001,7 +1001,7 @@ defmodule ExAdmin.Form do
     end
   end
 
-  defp build_select(_name, type, value, opts) do
+  defp build_select(_name, _type, value, opts) do
     value = if Range.range? value do
       Enum.map value, fn(x) -> 
         val = Integer.to_string x

--- a/lib/ex_admin/register.ex
+++ b/lib/ex_admin/register.ex
@@ -331,11 +331,7 @@ defmodule ExAdmin.Register do
       end
 
       controller_methods = Module.get_attribute(__MODULE__, :controller_methods)
-      page_name = case page_name do
-        atom when is_atom(atom) -> Atom.to_string atom
-        string -> string
-      end
-      # page_name = String.to_atom(page_name)
+      page_name = Kernel.to_string(page_name)
 
       plugs = case Module.get_attribute(__MODULE__, :controller_plugs) do
         nil -> []

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule ExAdmin.Mixfile do
       {:xain, github: "smpallen99/xain", override: true},
       {:scrivener, "~> 0.10.0"}, 
       {:csvlixir, "~> 1.0.0"},
-      {:exactor, "~>1.0.0"}, 
+      {:exactor, "~>2.2.0"}, 
       {:ex_doc, "~>0.10.0", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -8,7 +8,7 @@
   "ecto": {:hex, :ecto, "1.1.1"},
   "ex_doc": {:hex, :ex_doc, "0.10.0"},
   "ex_form": {:git, "https://github.com/smpallen99/ex_form.git", "6d08d449b112f89e48279daeca74b2b42a16fdda", []},
-  "exactor": {:hex, :exactor, "1.0.0"},
+  "exactor": {:hex, :exactor, "2.2.0"},
   "factory_girl_elixir": {:hex, :factory_girl_elixir, "0.1.1"},
   "fs": {:hex, :fs, "0.9.2"},
   "inflex": {:git, "https://github.com/smpallen99/inflex.git", "b7cef2d0e23ab5022595842e237611910c29d96d", []},


### PR DESCRIPTION
There were several warnings being generated by the macros provided
ExActor which were fixed by upgrading the version.

Several unused variable warnings have also been fixed.

Previously the following code:

    register_page("this will warn")

Would cause the following compiler warning:

 > warning: this expression will fail with ArgumentError

This is no longer the case, `Kernel.to_string` is used to allow anything
that implements the String.Chars protocol to be used.