### PR TITLE
Change including of admin routes to be more natural for Plug & Phoenix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,15 @@ defmodule MyProject.Router do
   use MyProject.Web, :router
   use ExAdmin.Router
   ...
-  # setup the ExAdmin routes
-  admin_routes
-
   scope "/", MyProject do
-  ...
+    ...
+  end
+
+  # setup the ExAdmin routes on /admin
+  scope "/admin", ExAdmin do
+    pipe_through :browser
+    admin_routes
+  end
 ```
 
 Add the paging configuration
@@ -182,23 +186,6 @@ defmodule Survey.ExAdmin.Question do
 end
 ```
 
-### Adding Route Plugins
-
-To change the route pipeline for ExAdmin, use the `:pipeline` option
-when calling `admin_routes` in your Router module.
-
-```elixir
-defmodule MyProject.Router do
-  use ExAdmin.Router
-
-  pipeline :browser do
-    ...
-  end
-
-  admin_routes pipeline: :browser
-  ...
-end
-```
 
 ## License
 

--- a/lib/mix/tasks/admin.install.ex
+++ b/lib/mix/tasks/admin.install.ex
@@ -78,8 +78,12 @@ defmodule Mix.Tasks.Admin.Install do
     IO.puts ""
     IO.puts "Add the admin routes to your web/router.ex:"
     IO.puts ""
-    IO.puts "    use ExAdmin.Router"
-    IO.puts "    admin_routes :admin"
+    IO.puts "    use ExAdmin.Router\n"
+    IO.puts "    # your app's routes\n"
+    IO.puts "    scope \"/admin\", ExAdmin do"
+    IO.puts "      pipe_through :browser"
+    IO.puts "      admin_routes"
+    IO.puts "    end"
     config
   end
   def do_route(config) do

--- a/web/router.ex
+++ b/web/router.ex
@@ -10,20 +10,16 @@ defmodule ExAdmin.Router do
         use MyProject.Web, :router
         use ExAdmin.Router
         ...
-        # setup the ExAdmin routes on /admin
-        admin_routes 
-
         scope "/", MyProject do
-        ...
+          ...
+        end
+
+        # setup the ExAdmin routes on /admin
+        scope "/admin", ExAdmin do
+          pipe_through :browser
+          admin_routes
+        end
       end
-
-  ## Options for `admin_routes`
-
-  * `admin_routes :administration` - Sets a custom route to `/administrator` 
-  * `admin_routes pipeline: :browser` - Uses your :browser pipeline
-    and the default `/admin` route.
-  * `admin-routes prefix: :administration, pipeline: :browser` - Uses
-    your existing `:browser` pipeline and the custom `/administrator` route.
   
   """
   use ExAdmin.Web, :router
@@ -35,48 +31,23 @@ defmodule ExAdmin.Router do
   end
 
   @doc """
-  Add ExAdmin Routes or your project's router
+  Add ExAdmin Routes to your project's router
 
   Adds the routes required for ExAdmin
-
-  ## Options
-
-  * `:prefix` - Change the `/admin` prefix.
-  * `:pipeline` - Use an existing pipeline.
   """
-  defmacro admin_routes(opts \\ :admin) do
+  defmacro admin_routes(_opts \\ []) do
     quote do
-      opts = case unquote(opts) do
-        list when is_list(list) -> 
-          Enum.into list, %{prefix: :admin, no_pipeline: list[:pipeline]}
-        name -> 
-          %{prefix: name, no_pipeline: false, pipeline: :admin}
-      end
-      prefix = opts[:prefix]
-      unless opts[:no_pipeline] do
-        pipeline opts[:pipeline] do
-          plug :accepts, ["html"]
-          plug :fetch_session
-          plug :fetch_flash
-          plug :protect_from_forgery
-          plug :put_secure_browser_headers
-        end
-      end
-      scope "/", ExAdmin do
-        pipe_through opts[:pipeline]
-        
-        get "/#{prefix}", AdminController, :index
-        get "/#{prefix}/:resource/", AdminController, :index
-        get "/#{prefix}/:resource/new", AdminController, :new
-        get "/#{prefix}/:resource/csv", AdminController, :csv
-        get "/#{prefix}/:resource/:id", AdminController, :show
-        get "/#{prefix}/:resource/:id/edit", AdminController, :edit
-        post "/#{prefix}/:resource/", AdminController, :create
-        patch "/#{prefix}/:resource/:id", AdminController, :update
-        put "/#{prefix}/:resource/:id", AdminController, :update
-        delete "/#{prefix}/:resource/:id", AdminController, :destroy
-        post "/#{prefix}/:resource/batch_action", AdminController, :batch_action
-      end
+      get "/", AdminController, :index
+      get "/:resource/", AdminController, :index
+      get "/:resource/new", AdminController, :new
+      get "/:resource/csv", AdminController, :csv
+      get "/:resource/:id", AdminController, :show
+      get "/:resource/:id/edit", AdminController, :edit
+      post "/:resource/", AdminController, :create
+      patch "/:resource/:id", AdminController, :update
+      put "/:resource/:id", AdminController, :update
+      delete "/:resource/:id", AdminController, :destroy
+      post "/:resource/batch_action", AdminController, :batch_action
     end
   end
 end


### PR DESCRIPTION
According to the principle of least astonishment I propose to use existing and already-known ways to configure admin routes.

``` elixir
defmodule MyProject.Router do
  use MyProject.Web, :router
  use ExAdmin.Router
  ...
  scope "/", MyProject do
    ...
  end

  # setup the ExAdmin routes on /admin
  scope "/admin", ExAdmin do
    pipe_through :browser
    admin_routes
  end
```