### PR TITLE
Added ability to use file upload in admin forms.

### DIFF
--- a/lib/ex_admin/form.ex
+++ b/lib/ex_admin/form.ex
@@ -463,7 +463,7 @@ defmodule ExAdmin.Form do
       action = get_action(conn, resource, mode)
       # scripts = ""
       Xain.form "accept-charset": "UTF-8", action: "#{action}", class: "formtastic #{model_name}", 
-          id: "new_#{model_name}", method: :post, novalidate: :novalidate  do
+          id: "new_#{model_name}", method: :post, enctype: "multipart/form-data", novalidate: :novalidate  do
 
         resource = setup_resource(resource, params, model_name)
 
@@ -1155,6 +1155,7 @@ defmodule ExAdmin.Form do
   end
 
   defp escape_value(nil), do: nil
+  defp escape_value(value) when is_map(value), do: value
   defp escape_value(value) do
     Phoenix.HTML.html_escape(value) |> elem(1)
   end

--- a/lib/ex_admin/form.ex
+++ b/lib/ex_admin/form.ex
@@ -860,13 +860,18 @@ defmodule ExAdmin.Form do
     build_errors(errors)
   end
 
-  def build_control(_type, resource, opts, model_name, field_name, ext_name, errors) do
+  def build_control(type, resource, opts, model_name, field_name, ext_name, errors) do
     # Logger.debug "build_control res: #{inspect resource}, name: #{inspect field_name} type: #{inspect _type}"
-    Map.put_new(opts, :type, :text)
+    {field_type, value} = if type |> Kernel.to_string |> String.ends_with?(".Type") do
+      {:file, Map.get(resource, field_name, "")[:file_name]}
+    else
+      {:text, Map.get(resource, field_name, "")}
+    end
+    Map.put_new(opts, :type, field_type)
     |> Map.put_new(:maxlength, "255")
     |> Map.put_new(:name, "#{model_name}[#{field_name}]")
     |> Map.put_new(:id, ext_name)
-    |> Map.put_new(:value, Map.get(resource, field_name, "") |> escape_value)
+    |> Map.put_new(:value, value |> escape_value)
     |> Map.delete(:display)
     |> Map.to_list
     |> Xain.input

--- a/lib/ex_admin/params_to_atoms.ex
+++ b/lib/ex_admin/params_to_atoms.ex
@@ -11,7 +11,7 @@ defmodule ExAdmin.ParamsToAtoms do
   # end
 
   def filter(params) do
-    Logger.warn "#{__MODULE__} filter/1 deprecated! Please use filter_parms/1"
+    Logger.warn "#{__MODULE__} filter/1 deprecated! Please use filter_params/1"
     filter_params(params)
   end
 
@@ -27,6 +27,9 @@ defmodule ExAdmin.ParamsToAtoms do
     Enum.into list, Map.new
   end
 
+  defp do_params_to_atoms(key, %Plug.Upload{} = value) do
+    {_to_atom(key), value}
+  end
   defp do_params_to_atoms(key, value) when is_map(value) do
     {_to_atom(key), params_to_atoms(value)}
   end
@@ -46,6 +49,7 @@ defmodule ExAdmin.ParamsToAtoms do
 
   defp _replace_integers(key, " " <> rest), do: _replace_integers(key, rest)
   defp _replace_integers(key, ""), do: {key, nil}
+  defp _replace_integers(key, %Plug.Upload{} = value), do: {key, value}
   defp _replace_integers(key, value) when is_integer(value), do: {key, value}
   defp _replace_integers(key, value) when is_map(value), do: {key, params_string_fields_to_integer(value)}
   defp _replace_integers(key, value) when is_atom(key) do


### PR DESCRIPTION
It allows to use `input[type="file"]` in admin forms. 
For example, for image uploading. Tested with https://github.com/stavro/arc_ecto
Fixes #33