### PR TITLE
bump version of scrivener

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,10 +35,10 @@ defmodule ExAdmin.Mixfile do
       {:inflex, github: "smpallen99/inflex"},
       {:ex_form, github: "smpallen99/ex_form"},
       {:xain, github: "smpallen99/xain", override: true},
-      {:scrivener, "~> 0.10.0"}, 
+      {:scrivener, "~> 1.0"}, 
       {:csvlixir, "~> 1.0.0"},
-      {:exactor, "~>2.2.0"}, 
-      {:ex_doc, "~>0.10.0", only: :dev},
+      {:exactor, "~> 2.2.0"}, 
+      {:ex_doc, "~> 0.10.0", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},
       {:ex_queb, github: "E-MetroTel/ex_queb"},
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -5,7 +5,7 @@
   "csvlixir": {:hex, :csvlixir, "1.0.0"},
   "decimal": {:hex, :decimal, "1.1.1"},
   "earmark": {:hex, :earmark, "0.2.1"},
-  "ecto": {:hex, :ecto, "1.1.1"},
+  "ecto": {:hex, :ecto, "1.1.5"},
   "ex_doc": {:hex, :ex_doc, "0.10.0"},
   "ex_form": {:git, "https://github.com/smpallen99/ex_form.git", "6d08d449b112f89e48279daeca74b2b42a16fdda", []},
   "ex_queb": {:git, "https://github.com/E-MetroTel/ex_queb.git", "8b61f174abafdb5b558f5afeb56f5f96844b09b2", []},
@@ -26,5 +26,5 @@
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "ranch": {:hex, :ranch, "1.2.0"},
   "sass_elixir": {:hex, :sass_elixir, "0.0.1"},
-  "scrivener": {:hex, :scrivener, "0.10.0"},
+  "scrivener": {:hex, :scrivener, "1.1.4"},
   "xain": {:git, "https://github.com/smpallen99/xain.git", "873a093453dfb23d95ef993077f9331bf87f04b3", []}}


### PR DESCRIPTION
I've bumped version of scrivener to 1.0, because 0.10 was dependent on ecto < 1.0.0.
This was causing deps conflict such as:
```
Dependencies have diverged:
* ecto (Hex package)
  the dependency ecto

  > In deps/sqlite_ecto/mix.exs:
    {:ecto, "~> 1.0", [optional: false, hex: :ecto, manager: :mix]}

  does not match the requirement specified

  > In deps/scrivener/mix.exs:
    {:ecto, "~> 0.13.0", [optional: false, hex: :ecto]}

  Ensure they match or specify one of the above in your deps and set "override: true"
** (Mix) Can't continue due to errors on dependencies
```

And solving this problem by overriding, is not good for user experience with ex_admin it self. 