### PR TITLE
Made fixes to solve https://github.com/smpallen99/ex_admin/issues/74

### DIFF
--- a/lib/ex_admin/ex_admin.ex
+++ b/lib/ex_admin/ex_admin.ex
@@ -153,9 +153,13 @@ defmodule ExAdmin do
   end
 
   @doc false
-  def get_registered_by_controller_route!(name) do
+  def get_registered_by_controller_route!(name, conn \\ %Plug.Conn{}) do
     res = get_registered_by_controller_route(name) 
-    if res == %{}, do: throw("Unknown Resource"), else: res
+    if res == %{} do 
+      raise Phoenix.Router.NoRouteError, conn: conn, router: __MODULE__
+    else
+      res
+    end
   end
 
   @doc false

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -6,6 +6,9 @@ defmodule ExAdminTest.ControllerTest do
   alias TestExAdmin.Noid
   alias TestExAdmin.User
 
+  @wrong_resource_id 100500
+  @wrong_endpoint "/admin/not_existing"
+
   setup do
     user = insert_user()
     {:ok, user: user}
@@ -22,5 +25,35 @@ defmodule ExAdminTest.ControllerTest do
     conn = get conn(), get_route_path(%User{}, :show, user.id)
     assert html_response(conn, 200) =~ ~r/User/
     assert String.contains?(conn.resp_body, ">Road Runner (Acme)<")
+  end
+
+  test "shows 404 for GET missing endpoint" do
+    conn = get conn(), @wrong_endpoint
+    assert html_response(conn, 404) =~ ~r/Not found/
+  end
+
+  test "shows 404 for POST missing endpoint" do
+    conn = post conn(), @wrong_endpoint
+    assert html_response(conn, 404) =~ ~r/Not found/
+  end
+
+  test "shows 404 for GET missing resource" do
+    conn = get conn(), get_route_path(%User{}, :show, @wrong_resource_id)
+    assert html_response(conn, 404) =~ ~r/Not found/
+  end
+
+  test "shows 404 for PATCH missing resource" do
+    conn = patch conn(), get_route_path(%User{}, :edit, @wrong_resource_id)
+    assert html_response(conn, 404) =~ ~r/Not found/
+  end
+
+  test "shows 404 for PUT missing resource" do
+    conn = put conn(), get_route_path(%User{}, :edit, @wrong_resource_id)
+    assert html_response(conn, 404) =~ ~r/Not found/
+  end
+
+  test "shows 404 for DELETE missing resource" do
+    conn = delete conn(), get_route_path(%User{}, :delete, @wrong_resource_id)
+    assert html_response(conn, 404) =~ ~r/Not found/
   end
 end

--- a/test/support/conn_case.exs
+++ b/test/support/conn_case.exs
@@ -27,6 +27,7 @@ defmodule TestExAdmin.ConnCase do
 
       import TestExAdmin.Router.Helpers
       import TestExAdmin.TestHelpers
+      import TestExAdmin.ErrorView
       import ExAdmin.Utils
 
       # The default endpoint for testing

--- a/test/support/error_view.ex
+++ b/test/support/error_view.ex
@@ -1,0 +1,13 @@
+defmodule TestExAdmin.ErrorView do
+  use Phoenix.View, root: ""
+  import Phoenix.Controller, only: [get_csrf_token: 0, get_flash: 2, view_module: 1]
+  use Phoenix.HTML
+
+  def render("404.html", _assigns) do
+    "Not found"
+  end
+
+  def render("500.html", _assigns) do
+    "Server internal error"
+  end
+ end

--- a/web/controllers/admin_controller.ex
+++ b/web/controllers/admin_controller.ex
@@ -32,9 +32,7 @@ defmodule ExAdmin.AdminController do
   defp handle_action(conn, action, resource) do
     conn = scrub_params(conn, resource, action)
     params = filter_params(conn.params)
-    case get_registered_by_controller_route(resource) do
-      nil ->
-        throw :invalid_route
+    case get_registered_by_controller_route!(resource, conn) do
       %{__struct__: _} = defn ->
         conn
         |> handle_plugs(action, defn)
@@ -110,10 +108,8 @@ defmodule ExAdmin.AdminController do
 
   def index(conn, params) do
     require Logger
-    defn = get_registered_by_controller_route(params[:resource])
+    defn = get_registered_by_controller_route!(params[:resource], conn)
     {contents, page} = case defn do
-      nil ->
-        throw :invalid_route
       %{type: :page} = defn ->
         {defn.__struct__ |> apply(:page_view, [conn]), nil}
       defn ->
@@ -138,10 +134,8 @@ defmodule ExAdmin.AdminController do
   end
 
   def show(conn, params) do
-
-    {contents, resource, defn} = case get_registered_by_controller_route(params[:resource]) do
-      nil ->
-        throw :invalid_route
+    registered = get_registered_by_controller_route!(params[:resource], conn)
+    {contents, resource, defn} = case registered do
       defn ->
         model = defn.__struct__
 
@@ -156,6 +150,11 @@ defmodule ExAdmin.AdminController do
         else
           model.run_query(repo, defn, :show, params[:id])
         end
+
+        if resource == nil do
+          raise Phoenix.Router.NoRouteError, conn: conn, router: __MODULE__
+        end
+
         if function_exported? model, :show_view, 2 do
           {apply(model, :show_view, [conn, resource]), resource, defn}
         else
@@ -166,12 +165,16 @@ defmodule ExAdmin.AdminController do
   end
 
   def edit(conn, params) do
-    {contents, resource, defn} = case get_registered_by_controller_route(params[:resource]) do
-      nil ->
-        throw :invalid_route
+    registered = get_registered_by_controller_route!(params[:resource], conn)
+    {contents, resource, defn} = case registered do
       defn ->
         model = defn.__struct__
         resource = model.run_query(repo, defn, :edit, params[:id])
+
+        if resource == nil do
+          raise Phoenix.Router.NoRouteError, conn: conn, router: __MODULE__
+        end
+
         if function_exported? model, :form_view, 3 do
           {apply(model, :form_view, [conn, resource, params]), resource, defn}
         else
@@ -182,9 +185,8 @@ defmodule ExAdmin.AdminController do
   end
 
   def new(conn, params) do
-    {contents, resource, defn} = case get_registered_by_controller_route(params[:resource]) do
-      nil ->
-        throw :invalid_route
+    registered = get_registered_by_controller_route!(params[:resource], conn)
+    {contents, resource, defn} = case registered do
       defn ->
         model = defn.__struct__
         resource = model.__struct__.resource_model.__struct__
@@ -202,9 +204,8 @@ defmodule ExAdmin.AdminController do
   end
 
   def create(conn, params) do
-    case get_registered_by_controller_route(params[:resource]) do
-      nil ->
-        throw :invalid_route
+    registered = get_registered_by_controller_route!(params[:resource], conn)
+    case registered do
       defn ->
         model = defn.__struct__
         resource = model.__struct__.resource_model.__struct__
@@ -226,14 +227,19 @@ defmodule ExAdmin.AdminController do
   end
 
   def update(conn, params) do
-    case get_registered_by_controller_route(params[:resource]) do
-      nil ->
-        throw :invalid_route
+    registered = get_registered_by_controller_route!(params[:resource], conn)
+    case registered do
       defn ->
+        IO.inspect defn
         model = defn.__struct__
         resource_model = model.__struct__.resource_model
         |> base_name |> String.downcase |> String.to_atom
         resource = model.run_query(repo, defn, :edit, params[:id])
+
+        if resource == nil do
+          raise Phoenix.Router.NoRouteError, conn: conn, router: __MODULE__
+        end
+
         changeset_fn = Keyword.get(defn.changesets, :update, &resource.__struct__.changeset/2)
         changeset = ExAdmin.Repo.changeset(changeset_fn, resource, params[resource_model])
         if changeset.valid? do
@@ -249,25 +255,30 @@ defmodule ExAdmin.AdminController do
   end
 
   def destroy(conn, params) do
-    resource_model =
-    case get_registered_by_controller_route(params[:resource]) do
-      nil ->
-        throw :invalid_route
-      defn ->
-        model = defn.__struct__
-        resource_model = model.__struct__.resource_model
-        |> base_name |> String.downcase |> String.to_atom
+    registered = get_registered_by_controller_route!(params[:resource], conn)
 
-        model.run_query(repo, defn, :edit, params[:id])
-        |> ExAdmin.Repo.delete(params[resource_model])
-        base_name model
-    end
+    resource_model =
+      case registered do
+        defn ->
+          model = defn.__struct__
+          resource_model = model.__struct__.resource_model
+          |> base_name |> String.downcase |> String.to_atom
+
+          resource = model.run_query(repo, defn, :edit, params[:id])
+          
+          if resource == nil do
+            raise Phoenix.Router.NoRouteError, conn: conn, router: __MODULE__
+          end
+
+          ExAdmin.Repo.delete(resource, params[resource_model])
+          base_name model
+      end
     put_flash(conn, :notice, "#{resource_model} was successfully destroyed.")
     |> redirect(to: get_route_path(conn, :index))
   end
 
   def batch_action(conn, %{batch_action: "destroy"} = params) do
-    defn = get_registered_by_controller_route!(params[:resource])
+    defn = get_registered_by_controller_route!(params[:resource], conn)
 
     model = defn.__struct__
     resource_model = model.__struct__.resource_model
@@ -298,9 +309,8 @@ defmodule ExAdmin.AdminController do
   end
 
   def csv(conn, params) do
-    case get_registered_by_controller_route(params[:resource]) do
-      nil ->
-        throw :invalid_route
+    registered = get_registered_by_controller_route!(params[:resource], conn)
+    case registered do
       defn ->
         model = defn.__struct__
 
@@ -320,20 +330,20 @@ defmodule ExAdmin.AdminController do
   @nested_key_list for i <- 1..5, do: {String.to_atom("nested#{i}"), String.to_atom("id#{i}")}
 
   def nested(conn, params) do
-    contents = case get_registered_by_controller_route(params[:resource]) do
-      nil ->
-        throw :invalid_route
-      defn ->
-        model = defn.__struct__
+    registered = get_registered_by_controller_route!(params[:resource], conn)
+    contents = 
+      case registered do
+        defn ->
+          model = defn.__struct__
 
-        items = apply(model, :get_blocks, [conn, defn.resource_model.__struct__, params])
-        block = deep_find(items, String.to_atom(params[:field_name]))
+          items = apply(model, :get_blocks, [conn, defn.resource_model.__struct__, params])
+          block = deep_find(items, String.to_atom(params[:field_name]))
 
-        resources = block[:opts][:collection].(conn, defn.resource_model.__struct__)
+          resources = block[:opts][:collection].(conn, defn.resource_model.__struct__)
 
-        contents = apply(model, :ajax_view, [conn, params, resources, block])
-        contents
-    end
+          contents = apply(model, :ajax_view, [conn, params, resources, block])
+          contents
+      end
     send_resp(conn, conn.status || 200, "text/javascript", contents)
   end
 


### PR DESCRIPTION
There are several improvements:
0. Refactored method `get_registered_by_controller_route!/1` to `get_registered_by_controller_route!/2` with optional parameter `conn` to save compatibility
1. Refactored to use `get_registered_by_controller_route!/2` everywhere when possible
2. Refactored method `get_registered_by_controller_route!/2` to raise `Phoenix.Router.NoRouteError`
3. Refactored `:show`, `:update`, `:edit`, `destroy` to raise `Phoenix.Router.NoRouteError` when resource is not found
4. Added tests to cover the changes