### PR TITLE
track priv/static/themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ lib/my_app/endpoint.ex
 
 ```
 
+Add `!priv/static/themes` to .gitignore to  Track `priv/static/themes` directory
+
+.gitignore
+```
+...
+!priv/static/themes
+```
+
 Start the application with `iex -S mix phoenix.server`
 
 Visit http://localhost:4000/admin


### PR DESCRIPTION
When using with git.
/priv/static is usually untracked.
To make it play nice with git we need to track /priv/static.

Thanks
Dev.