### PR TITLE
fix site title in ActiveAdmin theme

### DIFF
--- a/web/templates/themes/active_admin/layout/header.html.eex
+++ b/web/templates/themes/active_admin/layout/header.html.eex
@@ -1,5 +1,5 @@
 <div class="header" id="header">
-  <h1 class="site_title" id="site_title">ExAdminDemo</h1>
+  <h1 class="site_title" id="site_title"><%= ExAdmin.LayoutView.site_title %></h1>
   <ul class="header-item" id="tabs">
     <%= ExAdmin.Navigation.nav_view(@conn) %>
   </ul>


### PR DESCRIPTION
Hello. I'm using ex_admin 0.7.4 currently and it displays `ExAdminDemo` as site title in the navbar while in ActiveAdmin theme. I looked in the code and it seems title can be only configured for AdminLte2 theme. Here is quick fix for that, but maybe it's better to follow new theme and also use config value?