### PR TITLE
fix column in table_for renders empty with func

### DIFF
--- a/lib/ex_admin/table.ex
+++ b/lib/ex_admin/table.ex
@@ -62,7 +62,7 @@ defmodule ExAdmin.Table do
           tr(".#{odd_even}##{model_name}_#{tr_id}") do
             for field <- columns do
               case field do
-                {f_name, fun} when is_function(fun) ->
+                {f_name, %{fun: fun}} when is_function(fun) ->
                   td ".td-#{parameterize f_name} #{fun.(resource)}"
                 {f_name, opts} ->
                   build_field(resource, conn, {f_name, Enum.into(opts, %{})}, fn(contents, f_name) ->


### PR DESCRIPTION
This fixes a bug where the following code whould not behave as expected:
```elixir
show account do
  panel "Inventory" do
    table_for account.inventory do
      column "Asset", &__MODULE__.inventory_name/1
      column "PO", &(&1.sales_order.po)
      column :quantity
    end
  end
end
```
[this is taken from the docs](https://hexdocs.pm/ex_admin/ExAdmin.Show.html#table_for/3)

The problem happens because `ExAdmin.Register.column` puts the function inside the opts under the key `fun`. [see this](https://github.com/smpallen99/ex_admin/blob/v0.7.5/lib/ex_admin/register.ex#L645)