### PR TITLE
Encapsulate getting ExAdmin definition by controller path 

### DIFF
--- a/lib/ex_admin/breadcrumb.ex
+++ b/lib/ex_admin/breadcrumb.ex
@@ -3,9 +3,8 @@ defmodule ExAdmin.BreadCrumb do
   require Logger
 
   def get_breadcrumbs(conn, resource) do
-    defn = ExAdmin.get_registered_by_controller_route(conn.params["resource"])
-    get_breadcrumbs conn, resource, defn,
-     Map.get(defn, :page_name), conn.private[:phoenix_action]
+    defn = conn.assigns.defn
+    get_breadcrumbs conn, resource, defn, Map.get(defn, :page_name), conn.private[:phoenix_action]
   end
 
   defp get_breadcrumbs(conn, _resource, _, nil, :index) do

--- a/lib/ex_admin/controller_helpers.ex
+++ b/lib/ex_admin/controller_helpers.ex
@@ -1,0 +1,18 @@
+defmodule ExAdmin.ControllerHelpers do
+  @doc false
+  def get_registered_by_controller_route!(%Plug.Conn{} = conn, resource_name \\ nil) do
+    resource_name = resource_name || conn.params["resource"]
+    res = get_registered_by_controller_route(resource_name)
+    if res == %{} do
+      raise Phoenix.Router.NoRouteError, conn: conn, router: __MODULE__
+    else
+      res
+    end
+  end
+
+  @doc false
+  def get_registered_by_controller_route(resource_name) do
+    Enum.find ExAdmin.get_registered, %{}, &(Map.get(&1, :controller_route) == resource_name)
+  end
+
+end

--- a/lib/ex_admin/ex_admin.ex
+++ b/lib/ex_admin/ex_admin.ex
@@ -196,33 +196,6 @@ defmodule ExAdmin do
     Enum.find get_registered, %{}, &(Map.get(&1, :resource_model) == assoc_model)
   end
 
-  @doc false
-  def get_registered_by_controller_route!(name, conn \\ %Plug.Conn{}) do
-    res = get_registered_by_controller_route(name)
-    if res == %{} do
-      raise Phoenix.Router.NoRouteError, conn: conn, router: __MODULE__
-    else
-      res
-    end
-  end
-
-  @doc false
-  def get_registered_by_controller_route(%Plug.Conn{params: params}) do
-    get_registered_by_controller_route params["resource"]
-  end
-  @doc false
-  def get_registered_by_controller_route(path_info) when is_list(path_info) do
-    case path_info do
-      ["admin", route | _] -> route
-      _ -> ""
-    end
-    |> get_registered_by_controller_route
-  end
-
-  @doc false
-  def get_registered_by_controller_route(route) do
-    Enum.find get_registered, %{}, &(Map.get(&1, :controller_route) == route)
-  end
 
   @doc false
   def get_controller_path(%{} = resource) do
@@ -237,7 +210,7 @@ defmodule ExAdmin do
 
   @doc false
   def get_title_actions(%Plug.Conn{private: _private, path_info: path_info} = conn) do
-    defn = get_registered_by_controller_route(path_info)
+    defn = conn.assigns.defn
     fun = defn |> Map.get(:title_actions)
     fun.(conn, defn)
   end

--- a/lib/ex_admin/form.ex
+++ b/lib/ex_admin/form.ex
@@ -215,7 +215,7 @@ defmodule ExAdmin.Form do
       end
 
       def ajax_view(conn, params, resources, block) do
-        defn = ExAdmin.get_registered_by_controller_route(params[:resource])
+        defn = conn.assigns.defn
         resource = defn.resource_model.__struct__
         field_name = String.to_atom params[:field_name]
         model_name = model_name(resource)
@@ -1079,8 +1079,7 @@ defmodule ExAdmin.Form do
 
   @doc false
   def default_form_view(conn, resource, params) do
-    [_, res | _] = conn.path_info
-    case ExAdmin.get_registered_by_controller_route(res) do
+    case conn.assigns.defn do
       nil ->
         throw :invalid_route
       %{__struct__: _} = defn ->

--- a/lib/ex_admin/index.ex
+++ b/lib/ex_admin/index.ex
@@ -214,9 +214,7 @@ defmodule ExAdmin.Index do
 
   @doc false
   def default_index_view(conn, page, scope_counts) do
-    [_, resource] = conn.path_info
-
-    case ExAdmin.get_registered_by_controller_route(resource) do
+    case conn.assigns.defn do
       nil ->
         throw :invalid_route
       %{__struct__: _} = defn ->
@@ -255,7 +253,7 @@ defmodule ExAdmin.Index do
   @doc false
   def render_index_pages(conn, page, scope_counts, cell, page_opts) do
     name = resource_model(conn) |> titleize |> Inflex.pluralize
-    defn = ExAdmin.get_registered_by_controller_route(conn.params["resource"])
+    defn = conn.assigns.defn
     label = get_resource_label(conn) |> Inflex.pluralize
 
     opts = %{

--- a/lib/ex_admin/show.ex
+++ b/lib/ex_admin/show.ex
@@ -377,8 +377,7 @@ defmodule ExAdmin.Show do
 
   @doc false
   def default_attributes_table(conn, resource) do
-    [_, res | _] = conn.path_info
-    case ExAdmin.get_registered_by_controller_route(res) do
+    case conn.assigns.defn do
       nil ->
         throw :invalid_route
       %{__struct__: _} = defn ->

--- a/lib/ex_admin/utils.ex
+++ b/lib/ex_admin/utils.ex
@@ -115,8 +115,8 @@ defmodule ExAdmin.Utils do
   end
 
   @doc false
-  def resource_model(%Plug.Conn{path_info: path_info}) do
-    ExAdmin.get_registered_by_controller_route(path_info)
+  def resource_model(%Plug.Conn{} = conn) do
+    conn.assigns.defn
     |> Map.get(:resource_model)
     |> base_name
   end
@@ -305,7 +305,7 @@ defmodule ExAdmin.Utils do
 
   @doc false
   def get_resource_label(%Plug.Conn{} = conn) do
-    menu = ExAdmin.get_registered_by_controller_route!(conn).menu
+    menu = conn.assigns.defn.menu
     Map.get menu, :label, resource_model(conn)
   end
 

--- a/web/controllers/admin_association_controller.ex
+++ b/web/controllers/admin_association_controller.ex
@@ -4,8 +4,9 @@ defmodule ExAdmin.AdminAssociationController do
   require Logger
 
   def action(conn, _options) do
-    defn = ExAdmin.get_registered_by_controller_route!(conn.params["resource"], conn)
+    defn = get_registered_by_controller_route!(conn, conn.params["resource"])
     resource = repo.get!(defn.resource_model, conn.params["id"])
+    #conn = assign(conn, :defn, defn)
     apply(__MODULE__, action_name(conn), [conn, defn, resource, conn.params])
   end
 
@@ -22,7 +23,7 @@ defmodule ExAdmin.AdminAssociationController do
   end
 
   def index(conn, _defn, resource, %{"association_name" => association_name} = params) do
-    defn_assoc = ExAdmin.get_registered_by_controller_route!(association_name, conn)
+    defn_assoc = get_registered_by_controller_route!(conn, association_name)
     assoc_name = String.to_existing_atom(association_name)
 
     page = ExAdmin.Model.potential_associations_query(resource, defn_assoc.__struct__, assoc_name, params["keywords"])

--- a/web/controllers/admin_controller.ex
+++ b/web/controllers/admin_controller.ex
@@ -3,31 +3,17 @@ defmodule ExAdmin.AdminController do
   use ExAdmin.Web, :controller
   require Logger
 
-  plug :handle_root_req
   plug :set_theme
   plug :set_layout
 
-  # workaround for ExAdmin.get_registered_by_controller_route!
-  # ToDo: refactoring of ExAdmin.get_registered_by_controller_route!
-  def handle_root_req(conn, _params) do
-    case conn.path_info do
-      [prefix] ->
-        conn
-        |> struct(params: %{"resource" => "dashboard"})
-        |> struct(path_info: [prefix, "dashboard"])
-      [_prefix, "dashboard"] ->
-        conn
-        |> struct(params: %{"resource" => "dashboard"})
-      _ ->
-        conn
-    end
-  end
 
   def dashboard(conn, _params) do
-    defn = ExAdmin.get_registered_by_controller_route!(conn.params["resource"])
+    defn = get_registered_by_controller_route!(conn, "dashboard")
     contents = defn.__struct__ |> apply(:page_view, [conn])
 
-    assign(conn, :scope_counts, [])
+    conn
+    |> assign(:defn, defn)
+    |> assign(:scope_counts, [])
     |> render("admin.html", html: contents, defn: defn, resource: nil,
       filters: (if false in defn.index_filters, do: false, else: defn.index_filters))
   end

--- a/web/controllers/admin_controller.ex
+++ b/web/controllers/admin_controller.ex
@@ -9,17 +9,15 @@ defmodule ExAdmin.AdminController do
 
   def dashboard(conn, _params) do
     defn = get_registered_by_controller_route!(conn, "dashboard")
-    contents = defn.__struct__ |> apply(:page_view, [conn])
+    conn =  assign(conn, :defn, defn)
+    contents = defn.__struct__.page_view(conn)
 
-    conn
-    |> assign(:defn, defn)
-    |> assign(:scope_counts, [])
-    |> render("admin.html", html: contents, defn: defn, resource: nil,
+    render(conn, "admin.html", html: contents, resource: nil, scope_counts: [],
       filters: (if false in defn.index_filters, do: false, else: defn.index_filters))
   end
 
-  def select_theme(conn, params) do
-    {id, _} = Integer.parse(params["id"])
+  def select_theme(conn, %{"id" => id} = params) do
+    {id, _} = Integer.parse(id)
     {_, theme} = Application.get_env(:ex_admin, :theme_selector, []) |> Enum.at(id)
     loc = Map.get(params, "loc", admin_path) |> URI.parse |> Map.get(:path)
 

--- a/web/controllers/admin_resource_controller.ex
+++ b/web/controllers/admin_resource_controller.ex
@@ -145,7 +145,7 @@ defmodule ExAdmin.AdminResourceController do
     end
 
     assign(conn, :scope_counts, scope_counts)
-    |> render("admin.html", html: contents, defn: defn,# resource: page,
+    |> render("admin.html", html: contents, page: page,
       filters: (if false in defn.index_filters, do: false, else: defn.index_filters))
   end
 
@@ -161,7 +161,7 @@ defmodule ExAdmin.AdminResourceController do
       ExAdmin.Show.default_show_view(conn, resource)
     end
 
-    render conn, "admin.html", html: contents, resource: resource, filters: nil, defn: defn
+    render conn, "admin.html", html: contents, filters: nil
   end
 
   def edit(conn, defn, params) do
@@ -172,7 +172,7 @@ defmodule ExAdmin.AdminResourceController do
     {conn, params, resource} = handle_after_filter(conn, :edit, defn, params, resource)
     contents = do_form_view(model, conn, resource, params)
 
-    render conn, "admin.html", html: contents, resource: resource, filters: nil, defn: defn
+    render conn, "admin.html", html: contents, filters: nil
   end
 
   def new(conn, defn, params) do
@@ -183,7 +183,7 @@ defmodule ExAdmin.AdminResourceController do
     {conn, params, resource} = handle_after_filter(conn, :new, defn, params, resource)
     contents = do_form_view(model, conn, resource, params)
 
-    render conn, "admin.html", html: contents, resource: resource, filters: nil, defn: defn
+    render conn, "admin.html", html: contents, filters: nil
   end
 
   defp do_form_view(model, conn, resource, params) do
@@ -205,7 +205,7 @@ defmodule ExAdmin.AdminResourceController do
       {:error, changeset} ->
         conn = put_flash(conn, :inline_error, changeset.errors)
         contents = do_form_view model, conn, changeset.model, params
-        conn |> render("admin.html", html: contents, resource: resource, filters: nil, defn: defn)
+        conn |> render("admin.html", html: contents, filters: nil)
       resource ->
         {conn, _, resource} = handle_after_filter(conn, :create, defn, params, resource)
         put_flash(conn, :notice, "#{base_name model} was successfully created.")
@@ -224,7 +224,7 @@ defmodule ExAdmin.AdminResourceController do
       {:error, changeset} ->
         conn = put_flash(conn, :inline_error, changeset.errors)
         contents = do_form_view model, conn, changeset.model, params
-        conn |> render("admin.html", html: contents, resource: resource, filters: nil, defn: defn)
+        conn |> render("admin.html", html: contents, filters: nil)
       resource ->
         {conn, _, resource} = handle_after_filter(conn, :update, defn, params, resource)
         put_flash(conn, :notice, "#{base_name model} was successfully updated")

--- a/web/ex_admin/controller.ex
+++ b/web/ex_admin/controller.ex
@@ -1,4 +1,4 @@
-defmodule ExAdmin.ControllerHelpers do
+defmodule ExAdmin.Controller do
   @doc false
   def get_registered_by_controller_route!(%Plug.Conn{} = conn, resource_name \\ nil) do
     resource_name = resource_name || conn.params["resource"]

--- a/web/views/active_admin_view.ex
+++ b/web/views/active_admin_view.ex
@@ -68,7 +68,7 @@ defmodule ExAdmin.ActiveAdmin.LayoutView do
   def build_scopes(_conn, []), do: ""
   def build_scopes(_conn, nil), do: ""
   def build_scopes(conn, scope_counts) do
-    defn = ExAdmin.get_registered_by_controller_route(conn.params["resource"])
+    defn = conn.assigns.defn
     scopes = defn.scopes
     markup  do
       current_scope = ExAdmin.Query.get_scope scopes, conn.params["scope"]

--- a/web/views/admin_lte2_view.ex
+++ b/web/views/admin_lte2_view.ex
@@ -65,7 +65,7 @@ defmodule ExAdmin.AdminLte2.LayoutView do
   def build_scopes(_conn, []), do: ""
   def build_scopes(_conn, nil), do: ""
   def build_scopes(conn, scope_counts) do
-    defn = ExAdmin.get_registered_by_controller_route(conn.params["resource"])
+    defn = conn.assigns.defn
     scopes = defn.scopes
     markup  do
       current_scope = ExAdmin.Query.get_scope scopes, conn.params["scope"]

--- a/web/web.ex
+++ b/web/web.ex
@@ -20,7 +20,7 @@ defmodule ExAdmin.Web do
 
       import ExAdmin.Router.Helpers
       import ExAdmin.Utils, only: [admin_path: 0, admin_path: 2, admin_resource_path: 3, admin_association_path: 4]
-      import ExAdmin.ControllerHelpers
+      import ExAdmin.Controller
 
       defp set_theme(conn, _) do
         assign(conn, :theme, ExAdmin.theme)

--- a/web/web.ex
+++ b/web/web.ex
@@ -20,6 +20,7 @@ defmodule ExAdmin.Web do
 
       import ExAdmin.Router.Helpers
       import ExAdmin.Utils, only: [admin_path: 0, admin_path: 2, admin_resource_path: 3, admin_association_path: 4]
+      import ExAdmin.ControllerHelpers
 
       defp set_theme(conn, _) do
         assign(conn, :theme, ExAdmin.theme)


### PR DESCRIPTION
Call of `get_registered_by_controller_route!` should be done once per request and only from controller.