### PR TITLE
I18n support

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,6 +33,8 @@ use Mix.Config
 config :phoenix, :template_engines,
           haml: PhoenixHaml.Engine,
           eex: Phoenix.Template.EExEngine
+config :ex_admin,
+          module: ExAdmin
 
 # Sample configuration:
 #

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,8 +22,6 @@ config :ex_admin,
     TestExAdmin.ExAdmin.User,
     TestExAdmin.ExAdmin.Product,
     TestExAdmin.ExAdmin.Simple,
-    TestExAdmin.ExAdmin.ModelDisplayName,
-    TestExAdmin.ExAdmin.DefnDisplayName
   ]
 
 config :xain,

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,6 +22,8 @@ config :ex_admin,
     TestExAdmin.ExAdmin.User,
     TestExAdmin.ExAdmin.Product,
     TestExAdmin.ExAdmin.Simple,
+    TestExAdmin.ExAdmin.ModelDisplayName,
+    TestExAdmin.ExAdmin.DefnDisplayName
   ]
 
 config :xain,

--- a/lib/ex_admin/breadcrumb.ex
+++ b/lib/ex_admin/breadcrumb.ex
@@ -22,17 +22,15 @@ defmodule ExAdmin.BreadCrumb do
     end
   end
   defp get_breadcrumbs(conn, resource, defn, nil, action) when action in [:edit, :update] do
-    id = case resource.__struct__.__schema__(:primary_key) do
-      [key | _] -> Map.get resource, key
-      _ -> nil
+    {id, first} = case resource.__struct__.__schema__(:fields) do
+      [id, first | _] -> {Map.get(resource, id), Map.get(resource, first)}
     end
-    display_name = ExAdmin.Helpers.display_name(resource)
     get_breadcrumbs(conn, resource, defn, nil, :new) ++
     case conn.path_info do
       [admin, name | _] ->
         resource_link = admin_link(admin)
         |> resource_link(name)
-        [{resource_link <> "/#{id}", get_name(id, display_name)}]
+        [{resource_link <> "/#{id}", get_name(id, first)}]
       _ -> []
     end
   end

--- a/lib/ex_admin/breadcrumb.ex
+++ b/lib/ex_admin/breadcrumb.ex
@@ -22,15 +22,17 @@ defmodule ExAdmin.BreadCrumb do
     end
   end
   defp get_breadcrumbs(conn, resource, defn, nil, action) when action in [:edit, :update] do
-    {id, first} = case resource.__struct__.__schema__(:fields) do
-      [id, first | _] -> {Map.get(resource, id), Map.get(resource, first)}
+    id = case resource.__struct__.__schema__(:primary_key) do
+      [key | _] -> Map.get resource, key
+      _ -> nil
     end
+    display_name = ExAdmin.Helpers.display_name(resource)
     get_breadcrumbs(conn, resource, defn, nil, :new) ++
     case conn.path_info do
       [admin, name | _] ->
         resource_link = admin_link(admin)
         |> resource_link(name)
-        [{resource_link <> "/#{id}", get_name(id, first)}]
+        [{resource_link <> "/#{id}", get_name(id, display_name)}]
       _ -> []
     end
   end

--- a/lib/ex_admin/filter.ex
+++ b/lib/ex_admin/filter.ex
@@ -5,9 +5,10 @@ defmodule ExAdmin.Filter do
   require Ecto.Query
   import ExAdmin.Theme.Helpers
   import ExAdmin.Utils
+  import ExAdmin.Gettext
   use Xain
 
-  @integer_options [eq: "Equal To", gt: "Greater Than", lt: "Less Than" ]
+  @integer_options [eq: (gettext "Equal To"), gt: (gettext "Greater Than"), lt: (gettext "Less Than") ]
 
   def integer_options, do: @integer_options
 

--- a/lib/ex_admin/form/fields.ex
+++ b/lib/ex_admin/form/fields.ex
@@ -4,6 +4,7 @@ defmodule ExAdmin.Form.Fields do
   import ExAdmin.Utils
   import ExAdmin.Helpers
   import ExAdmin.Theme.Helpers
+  import ExAdmin.Gettext
   import Xain, except: [input: 1]
 
   def ext_name(model_name, field_name), do: "#{model_name}_#{field_name}"
@@ -146,7 +147,7 @@ defmodule ExAdmin.Form.Fields do
       nil ->
         nm = humanize("#{field_name}")
         |> articlize
-        "Select #{nm}"
+        (gettext "Select %{nm}",nm: nm)
       other -> other
     end
   end

--- a/lib/ex_admin/gettext.ex
+++ b/lib/ex_admin/gettext.ex
@@ -1,0 +1,3 @@
+defmodule ExAdmin.Gettext do
+  use Gettext, otp_app: :ex_admin
+end

--- a/lib/ex_admin/index.ex
+++ b/lib/ex_admin/index.ex
@@ -110,6 +110,7 @@ defmodule ExAdmin.Index do
   require Integer
   import ExAdmin.Utils
   import ExAdmin.Helpers
+  import ExAdmin.Gettext
   import Kernel, except: [div: 2, to_string: 1]
   use Xain
   # alias ExAdmin.Schema
@@ -343,7 +344,7 @@ defmodule ExAdmin.Index do
 
   @doc false
   def download_links(conn) do
-    div ".download_links Download: " do
+    div ".download_links " <> (gettext "Download:") <> " " do
       a "CSV", href: admin_resource_path(conn, :csv)
     end
   end

--- a/lib/ex_admin/paginate.ex
+++ b/lib/ex_admin/paginate.ex
@@ -2,6 +2,7 @@ defmodule ExAdmin.Paginate do
   @moduledoc false
   use Xain
   import ExAdmin.Theme.Helpers
+  import ExAdmin.Gettext
 
   def paginate(_, nil, _, _, _, _, _), do: []
   def paginate(link, page_number, page_size, total_pages, record_count, name) do
@@ -34,37 +35,37 @@ defmodule ExAdmin.Paginate do
 
   def pagination_information(name, record_number, record_number, record_count) do
     markup do
-      text "Displaying " <> Inflex.singularize("#{name}") <> " "
-      b "#{record_number}"
-      text " of "
-      b "#{record_count}"
-      text " in total"
+      text (gettext "Displaying") <> Inflex.singularize(" #{name}") <> " "
+      b "#{record_number} "
+      text gettext "of"
+      b " #{record_count} "
+      text gettext "in total"
     end
   end
 
   def pagination_information(name, record_number, last, record_count) do
     markup do
-      text "Displaying #{name} "
-      b "#{record_number}&nbsp;-&nbsp;#{last}"
-      text " of "
-      b "#{record_count}"
-      text " in total"
+      text (gettext "Displaying %{name}", name: name)
+      b " #{record_number}&nbsp;-&nbsp;#{last} "
+      text gettext "of"
+      b " #{record_count} "
+      text gettext "in total"
     end
   end
 
   def pagination_information(name, total) do
     markup do
-      text "Displaying "
-      b "all #{total}"
+      text gettext "Displaying" <> " "
+      b (gettext "all %{total}", total: total)
       text " #{name}"
     end
   end
 
 
-  def special_name(:first), do: "« First"
-  def special_name(:prev), do: "‹ Prev"
-  def special_name(:next), do: "Next ›"
-  def special_name(:last), do: "Last »"
+  def special_name(:first), do: gettext "« First"
+  def special_name(:prev), do: gettext "‹ Prev"
+  def special_name(:next), do: gettext "Next ›"
+  def special_name(:last), do: gettext "Last »"
 
   def window_size, do: 7
 

--- a/lib/ex_admin/paginate.ex
+++ b/lib/ex_admin/paginate.ex
@@ -36,20 +36,20 @@ defmodule ExAdmin.Paginate do
   def pagination_information(name, record_number, record_number, record_count) do
     markup do
       text (gettext "Displaying") <> Inflex.singularize(" #{name}") <> " "
-      b "#{record_number} "
-      text gettext "of"
-      b " #{record_count} "
-      text gettext "in total"
+      b "#{record_number}"
+      text " " <> (gettext "of") <> " "
+      b "#{record_count}"
+      text " " <> (gettext "in total")
     end
   end
 
   def pagination_information(name, record_number, last, record_count) do
     markup do
-      text (gettext "Displaying %{name}", name: name)
-      b " #{record_number}&nbsp;-&nbsp;#{last} "
-      text gettext "of"
-      b " #{record_count} "
-      text gettext "in total"
+      text (gettext "Displaying %{name}", name: name) <> " "
+      b "#{record_number}&nbsp;-&nbsp;#{last}"
+      text " " <> (gettext "of") <> " "
+      b "#{record_count}"
+      text " " <> (gettext "in total")
     end
   end
 

--- a/lib/ex_admin/table.ex
+++ b/lib/ex_admin/table.ex
@@ -7,6 +7,7 @@ defmodule ExAdmin.Table do
   import ExAdmin.Utils
   import ExAdmin.Render
   import ExAdmin.Theme.Helpers
+  import ExAdmin.Gettext
   import Kernel, except: [to_string: 1]
   alias ExAdmin.Schema
 

--- a/lib/ex_admin/themes/active_admin/filter.ex
+++ b/lib/ex_admin/themes/active_admin/filter.ex
@@ -4,13 +4,14 @@ defmodule ExAdmin.Theme.ActiveAdmin.Filter do
   require Logger
   require Ecto.Query
   import ExAdmin.Utils
+  import ExAdmin.Gettext
   import ExAdmin.Filter
   use Xain
 
   def theme_filter_view(conn, defn, q, order, scope) do
     markup safe: true do
       div "#filters_sidebar_sectionl.sidebar_section.panel" do
-        h3 "Filters"
+        h3 (gettext "Filters")
         div ".panel_contents" do
           form "accept-charset": "UTF-8", action: admin_resource_path(conn, :index), class: "filter_form", id: "q_search", method: "get" do
             if scope do
@@ -18,7 +19,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Filter do
             end
             for field <- fields(defn), do: build_field(field, q, defn)
             div ".buttons" do
-              input name: "commit", type: "submit", value: "Filter"
+              input name: "commit", type: "submit", value: (gettext "Filter")
               a ".clear_filters_btn Clear Filters", href: "#"
               order_value = if order, do: order, else: "id_desc"
               input id: "order", name: "order", type: :hidden, value: order_value
@@ -35,7 +36,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Filter do
     name_field = "#{name}_contains"
     value = if q, do: Map.get(q, name_field, ""), else: ""
     div ".filter_form_field.filter_string" do
-      label ".label Search #{name_label}", for: "q_#{name}"
+      label ".label " <> (gettext "Search %{name_label}", name_label: name_label), for: "q_#{name}"
       input id: "q_#{name}", name: "q[#{name_field}]", type: :text, value: value
     end
   end

--- a/lib/ex_admin/themes/active_admin/form.ex
+++ b/lib/ex_admin/themes/active_admin/form.ex
@@ -7,6 +7,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Form do
   require Integer
   require Logger
   import ExAdmin.Helpers
+  import ExAdmin.Gettext
   alias ExAdmin.Schema
 
   @doc false
@@ -98,14 +99,14 @@ defmodule ExAdmin.Theme.ActiveAdmin.Form do
 
   def build_actions_block(conn, model_name, mode) do
     display_name = ExAdmin.Utils.displayable_name_singular conn
-    label = if mode == :new, do: "Create", else: "Update"
+    label = if mode == :new, do: (gettext "Create"), else: (gettext "Update")
     fieldset(".actions") do
       ol do
         li(".action.input_action##{model_name}_submit_action") do
           Xain.input name: "commit", type: :submit, value: escape_value("#{label} #{humanize display_name}")
         end
         li(".cancel") do
-          a("Cancel", href: admin_resource_path(conn, :index))
+          a((gettext "Cancel"), href: admin_resource_path(conn, :index))
         end
       end
     end
@@ -197,7 +198,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Form do
           Xain.input type: :hidden, value: "0", name: name
           label for: base_id do
             Xain.input type: :checkbox, id: "#{base_id}", name: name, value: "1"
-            text "Remove"
+            text (gettext "Remove")
           end
         end
 
@@ -241,7 +242,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Form do
         end
         unless Schema.get_id(res) do
           li do
-            a ".button Delete", href: "#",
+            a ".button " <> (gettext "Delete"), href: "#",
               onclick: ~S|$(this).closest(\".has_many_fields\").remove(); return false;|
           end
         end

--- a/lib/ex_admin/themes/active_admin/index.ex
+++ b/lib/ex_admin/themes/active_admin/index.ex
@@ -6,6 +6,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Index do
   import ExAdmin.Index
   require Integer
   import ExAdmin.Helpers
+  import ExAdmin.Gettext
   require Logger
   alias ExAdmin.Schema
 
@@ -25,11 +26,11 @@ defmodule ExAdmin.Theme.ActiveAdmin.Index do
     div ".blank_slate_container" do
       span ".blank_slate" do
         unless is_nil(conn.params["q"]) and is_nil(conn.params["scope"]) do
-          text "No #{humanize label} found."
+          text (gettext"No %{label} found.", label: (humanize label))
         else
-          text "There are no #{humanize label} yet. "
+          text (gettext"There are no %{label} yet. ", label: (humanize label))
           if ExAdmin.has_action?(conn, defn, :new) do
-            a "Create one", href: admin_resource_path(conn, :new)
+            a (gettext "Create one"), href: admin_resource_path(conn, :new)
           end
         end
       end
@@ -107,11 +108,11 @@ defmodule ExAdmin.Theme.ActiveAdmin.Index do
     |> Enum.reduce([], fn(item, acc) ->
       link = case item do
         :show ->
-          a("View", href: admin_resource_path(resource, :show), class: base_class <> " view_link")
+          a((gettext "View"), href: admin_resource_path(resource, :show), class: base_class <> " view_link")
         :edit ->
-          a("Edit", href: admin_resource_path(resource, :edit), class: base_class <> " edit_link")
+          a((gettext "Edit"), href: admin_resource_path(resource, :edit), class: base_class <> " edit_link")
         :destroy ->
-          a("Delete", href: admin_resource_path(resource, :destroy),
+          a((gettext "Delete"), href: admin_resource_path(resource, :destroy),
               class: base_class <> " delete_link", "data-confirm": confirm_message,
               "data-remote": true,
               "data-method": :delete, rel: :nofollow )
@@ -122,7 +123,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Index do
   end
 
   def batch_action_form conn, enabled?, scopes, name, scope_counts, fun do
-    msg = "Are you sure you want to delete these #{name}? You wont be able to undo this."
+    msg = gettext "Are you sure you want to delete these %{name}? You wont be able to undo this.", name: name
     scopes = unless Application.get_env(:ex_admin, :scopes_index_page, true), do: [], else: scopes
     if enabled? or scopes != [] do
       form "#collection_selection", action: "/admin/#{name}/batch_action", method: :post, "accept-charset": "UTF-8" do
@@ -136,14 +137,14 @@ defmodule ExAdmin.Theme.ActiveAdmin.Index do
           div ".table_tools" do
             if enabled? do
               div "#batch_actions_selector.dropdown_menu" do
-                button ".disabled.dropdown_menu_button.btn.btn-xs.btn-default Batch Actions " do
+                button ".disabled.dropdown_menu_button.btn.btn-xs.btn-default " <> (gettext "Batch Actions") do
                   span ".fa.fa-caret-down"
                 end
                 div ".dropdown_menu_list_wrapper", style: "display: none;" do
                   div ".dropdown_menu_nipple"
                   ul ".dropdown_menu_list" do
                     li do
-                      a ".batch_action Delete Selected", href: "#", "data-action": :destroy, "data-confirm": msg
+                      a ".batch_action " <> (gettext "Delete Selected"), href: "#", "data-action": :destroy, "data-confirm": msg
                     end
                   end
                 end

--- a/lib/ex_admin/themes/active_admin/table.ex
+++ b/lib/ex_admin/themes/active_admin/table.ex
@@ -1,6 +1,7 @@
 defmodule ExAdmin.Theme.ActiveAdmin.Table do
   @moduledoc false
   import ExAdmin.Table
+  import ExAdmin.Gettext
   use Xain
 
   @table_opts [border: "0", cellspacing: "0", cellpadding: "0"]
@@ -16,7 +17,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Table do
 
   def theme_attributes_table(conn, resource, schema, resource_model) do
     div(".panel") do
-      h3(schema[:name] || "#{String.capitalize resource_model} Details")
+      h3(schema[:name] || (gettext "%{resource_model} Details", resource_model: String.capitalize resource_model))
       do_attributes_table_for(conn, resource, resource_model, schema, @table_opts)
     end
   end

--- a/lib/ex_admin/themes/admin_lte2/filter.ex
+++ b/lib/ex_admin/themes/admin_lte2/filter.ex
@@ -4,6 +4,7 @@ defmodule ExAdmin.Theme.AdminLte2.Filter do
   require Logger
   require Ecto.Query
   import ExAdmin.Utils
+  import ExAdmin.Gettext
   import ExAdmin.Filter
   use Xain
 
@@ -11,7 +12,7 @@ defmodule ExAdmin.Theme.AdminLte2.Filter do
     markup safe: true do
       div ".box.box-primary" do
         div ".box-header.with-border" do
-          h3 ".box-title Filters"
+          h3 ".box-title " <> (gettext "Filters")
         end
         form "accept-charset": "UTF-8", action: admin_resource_path(conn, :index), class: "filter_form", id: "q_search", method: "get" do
           div ".box-body.sidebar_section" do
@@ -21,8 +22,8 @@ defmodule ExAdmin.Theme.AdminLte2.Filter do
             for field <- fields(defn), do: build_field(field, q, defn)
           end
           div ".box-footer" do
-            input name: "commit", type: "submit", value: "Filter", class: "btn btn-primary"
-            a ".clear_filters_btn Clear Filters", href: "#", style: "padding-left: 10px"
+            input name: "commit", type: "submit", value: (gettext "Filter"), class: "btn btn-primary"
+            a ".clear_filters_btn " <> (gettext "Clear Filters"), href: "#", style: "padding-left: 10px"
             order_value = if order, do: order, else: "id_desc"
             input id: "order", name: "order", type: :hidden, value: order_value
           end
@@ -37,7 +38,7 @@ defmodule ExAdmin.Theme.AdminLte2.Filter do
     name_field = "#{name}_contains"
     value = if q, do: Map.get(q, name_field, ""), else: ""
     div ".form-group" do
-      label ".label Search #{name_label}", for: "q_#{name}"
+      label ".label " <> (gettext "Search %{name_label}", name_label: name_label), for: "q_#{name}"
       input id: "q_#{name}", name: "q[#{name_field}]", type: :text, value: value, class: "form-control"
     end
   end

--- a/lib/ex_admin/themes/admin_lte2/form.ex
+++ b/lib/ex_admin/themes/admin_lte2/form.ex
@@ -7,6 +7,7 @@ defmodule ExAdmin.Theme.AdminLte2.Form do
   require Integer
   use ExAdmin.Adminlog
   import ExAdmin.Helpers
+  import ExAdmin.Gettext
   alias ExAdmin.Schema
 
   @doc false
@@ -93,10 +94,10 @@ defmodule ExAdmin.Theme.AdminLte2.Form do
 
   def build_actions_block(conn, _model_name, mode) do
     display_name = ExAdmin.Utils.displayable_name_singular conn
-    label = if mode == :new, do: "Create", else: "Update"
+    label = if mode == :new, do: (gettext "Create"), else: (gettext "Update")
     div ".box-footer" do
       Xain.input ".btn.btn-primary", name: "commit", type: :submit, value: escape_value("#{label} #{humanize display_name}")
-      a(".btn.btn-default.btn-cancel Cancel", href: admin_resource_path(conn, :index))
+      a(".btn.btn-default.btn-cancel " <> (gettext "Cancel"), href: admin_resource_path(conn, :index))
     end
   end
 
@@ -184,7 +185,7 @@ defmodule ExAdmin.Theme.AdminLte2.Form do
               Xain.input type: :hidden, value: "0", name: name
               label for: base_id do
                 Xain.input type: :checkbox, id: "#{base_id}", name: name, value: "1"
-                text "Remove"
+                text (gettext "Remove")
               end
             end
           end
@@ -234,7 +235,7 @@ defmodule ExAdmin.Theme.AdminLte2.Form do
         end
         unless Schema.get_id(res) do
           div ".form-group" do
-            a ".btn.btn-default Delete", href: "#",
+            a ".btn.btn-default " <> (gettext "Delete"), href: "#",
               onclick: ~S|$(this).closest(\".has_many_fields\").remove(); return false;|
           end
         end

--- a/lib/ex_admin/themes/admin_lte2/index.ex
+++ b/lib/ex_admin/themes/admin_lte2/index.ex
@@ -6,6 +6,7 @@ defmodule ExAdmin.Theme.AdminLte2.Index do
   import ExAdmin.Index
   require Integer
   import ExAdmin.Helpers
+  import ExAdmin.Gettext
   alias ExAdmin.Schema
 
   def wrap_index_grid(fun) do
@@ -24,11 +25,11 @@ defmodule ExAdmin.Theme.AdminLte2.Index do
     div ".blank_slate_container" do
       span ".blank_slate" do
         unless is_nil(conn.params["q"]) and is_nil(conn.params["scope"]) do
-          text "No #{humanize label} found."
+          text (gettext"No %{label} found.", label: (humanize label))
         else
-          text "There are no #{humanize label} yet. "
+          text (gettext"There are no %{label} yet. ", label: (humanize label))
           if ExAdmin.has_action?(conn, defn, :new) do
-            a "Create one", href: admin_resource_path(conn, :new)
+            a (gettext "Create one"), href: admin_resource_path(conn, :new)
           end
         end
       end
@@ -101,11 +102,11 @@ defmodule ExAdmin.Theme.AdminLte2.Index do
     |> Enum.reduce([], fn(item, acc) ->
       link = case item do
         :show ->
-          a("View", href: admin_resource_path(resource, :show), class: base_class <> " view_link")
+          a((gettext "View"), href: admin_resource_path(resource, :show), class: base_class <> " view_link")
         :edit ->
-          a("Edit", href: admin_resource_path(resource, :edit), class: base_class <> " edit_link")
+          a((gettext "Edit"), href: admin_resource_path(resource, :edit), class: base_class <> " edit_link")
         :destroy ->
-          a("Delete", href: admin_resource_path(resource, :destroy),
+          a((gettext "Delete"), href: admin_resource_path(resource, :destroy),
               class: base_class <> " delete_link", "data-confirm": confirm_message,
               "data-remote": true,
               "data-method": :delete, rel: :nofollow )
@@ -116,7 +117,7 @@ defmodule ExAdmin.Theme.AdminLte2.Index do
   end
 
   def batch_action_form conn, enabled?, scopes, name, scope_counts, fun do
-    msg = "Are you sure you want to delete these #{name}? You wont be able to undo this."
+    msg = gettext "Are you sure you want to delete these %{name}? You wont be able to undo this.", name: name
     scopes = unless Application.get_env(:ex_admin, :scopes_index_page, true), do: [], else: scopes
     if enabled? or scopes != [] do
       form "#collection_selection", action: "/admin/#{name}/batch_action", method: :post, "accept-charset": "UTF-8" do
@@ -130,14 +131,14 @@ defmodule ExAdmin.Theme.AdminLte2.Index do
           div ".table_tools" do
             if enabled? do
               div "#batch_actions_selector.dropdown_menu" do
-                button ".disabled.dropdown_menu_button.btn.btn-xs.btn-default Batch Actions " do
+                button ".disabled.dropdown_menu_button.btn.btn-xs.btn-default " <> (gettext "Batch Actions") do
                   span ".fa.fa-caret-down"
                 end
                 div ".dropdown_menu_list_wrapper", style: "display: none;" do
                   div ".dropdown_menu_nipple"
                   ul ".dropdown_menu_list" do
                     li do
-                      a ".batch_action Delete Selected", href: "#", "data-action": :destroy, "data-confirm": msg
+                      a ".batch_action " <> (gettext "Delete Selected"), href: "#", "data-action": :destroy, "data-confirm": msg
                     end
                   end
                 end

--- a/lib/ex_admin/themes/admin_lte2/table.ex
+++ b/lib/ex_admin/themes/admin_lte2/table.ex
@@ -2,6 +2,7 @@ defmodule ExAdmin.Theme.AdminLte2.Table do
   @moduledoc false
   # import Phoenix.HTML.Tag, only: [content_tag: 2, content_tag: 3]
   import ExAdmin.Table
+  import ExAdmin.Gettext
   use Xain
 
   @table_opts [class: "table"]
@@ -22,7 +23,7 @@ defmodule ExAdmin.Theme.AdminLte2.Table do
   def theme_attributes_table(conn, resource, schema, resource_model) do
     div ".box" do
       div ".box-header.with-border"  do
-        h3(schema[:name] || "#{String.capitalize resource_model} Details")
+        h3(schema[:name] || (gettext "%{resource_model} Details", resource_model: String.capitalize resource_model))
       end
       div ".box-body" do
         do_attributes_table_for(conn, resource, resource_model, schema, @table_opts)

--- a/lib/ex_admin/utils.ex
+++ b/lib/ex_admin/utils.ex
@@ -4,6 +4,7 @@ defmodule ExAdmin.Utils do
   """
   require Logger
   import Ecto.DateTime.Utils, only: [zero_pad: 2]
+  import ExAdmin.Gettext
   @module Application.get_env(:ex_admin, :module)
   if @module do
     @endpoint Module.concat([@module, "Endpoint"])
@@ -107,10 +108,10 @@ defmodule ExAdmin.Utils do
   """
   def articlize(string) when is_binary(string) do
     if String.at(string, 0) in ~w(A a E e I i O o U u) do
-      "an "
+      gettext "an"
     else
-      "a "
-    end <> string
+      gettext "a"
+    end <> " " <> string
   end
 
   def parameterize(atom) when is_atom(atom),
@@ -268,7 +269,7 @@ defmodule ExAdmin.Utils do
 
 
   @doc false
-  def confirm_message, do: "Are you sure you want to delete this?"
+  def confirm_message, do: gettext "Are you sure you want to delete this?"
 
   @doc false
   def to_datetime(%Ecto.DateTime{} = dt) do

--- a/lib/ex_admin/view_helpers.ex
+++ b/lib/ex_admin/view_helpers.ex
@@ -2,6 +2,7 @@ defmodule ExAdmin.ViewHelpers do
   @moduledoc false
   use Xain
   import ExAdmin.Utils
+  import ExAdmin.Gettext
   require Logger
 
   @endpoint Application.get_env(:ex_admin, :endpoint)
@@ -52,9 +53,9 @@ defmodule ExAdmin.ViewHelpers do
             ExAdmin.Helpers.resource_identity(resource)
         end
       action when action in [:edit, :update] ->
-        "Edit #{singular}"
+        (gettext "Edit") <> " #{singular}"
       action when action in [:new, :create] ->
-        "New #{singular}"
+        (gettext "New") <> " #{singular}"
       _ ->
         ""
     end

--- a/lib/mix/tasks/admin.install.ex
+++ b/lib/mix/tasks/admin.install.ex
@@ -23,6 +23,7 @@ defmodule Mix.Tasks.Admin.Install do
 
   use Mix.Task
   import Mix.ExAdmin.Utils
+  import ExAdmin.Gettext
 
   defmodule Config do
     defstruct route: true, assets: true, dashboard: true,
@@ -135,7 +136,11 @@ defmodule Mix.Tasks.Admin.Install do
     dest_path = Path.join [File.cwd! | ~w(web admin)]
     dest_file_path = Path.join dest_path, "dashboard.ex"
     source = Path.join([config.package_path | ~w(priv templates admin.install dashboard.exs)] )
-    |> EEx.eval_file(base: get_module)
+    |> EEx.eval_file([base: get_module,
+      title_txt: (gettext "Dashboard"),
+      welcome_txt: (gettext "Welcome to ExAdmin. This is the default dashboard page."),
+      add_txt: (gettext "To add dashboard sections, checkout 'web/admin/dashboards.ex'")
+      ])
 
     file = Path.join(~w(web admin dashboard.ex))
     if File.exists?(file) do

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule ExAdmin.Mixfile do
       version: @version,
       elixir: "~> 1.2",
       elixirc_paths: elixirc_paths(Mix.env),
-      compilers: [:phoenix] ++ Mix.compilers,
+      compilers: [:phoenix, :gettext] ++ Mix.compilers,
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       name: "ExAdmin",
@@ -29,7 +29,7 @@ defmodule ExAdmin.Mixfile do
     [:plug | applications(:prod)]
   end
   defp applications(_) do
-    [:phoenix, :ecto, :logger, :ex_queb, :xain]
+    [:gettext, :phoenix, :ecto, :logger, :ex_queb, :xain]
   end
 
   defp elixirc_paths(:test), do: ["lib", "web", "test/support"]
@@ -54,6 +54,7 @@ defmodule ExAdmin.Mixfile do
       {:ex_doc, "~> 0.11", only: :dev},
       {:earmark, "~> 0.1", only: :dev},
       {:ex_queb, "~> 0.1"},
+      {:gettext, "~> 0.11"}
     ]
   end
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -126,6 +126,7 @@ msgstr ""
 msgid "Download:"
 msgstr ""
 
+#: web/templates/themes/active_admin/layout/header.html.eex:11
 #: web/templates/themes/admin_lte2/layout/header.html.eex:25
 msgid "Logout"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1,0 +1,237 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+"Language: INSERT LANGUAGE HERE\n"
+
+#: web/controllers/admin_resource_controller.ex:303
+msgid "was successfully destroyed."
+msgid_plural "were successfully destroyed."
+msgstr[0] ""
+msgstr[1] ""
+
+#: web/templates/themes/admin_lte2/layout/header.html.eex:63
+msgid "ACTIONS"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/index.ex:140
+#: lib/ex_admin/themes/admin_lte2/index.ex:134
+msgid "Batch Actions"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/index.ex:33
+#: lib/ex_admin/themes/admin_lte2/index.ex:32
+msgid "Create one"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/index.ex:113
+#: lib/ex_admin/themes/admin_lte2/index.ex:107 lib/ex_admin/view_helpers.ex:56
+msgid "Edit"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/filter.ex:14
+#: lib/ex_admin/themes/admin_lte2/filter.ex:15
+msgid "Filters"
+msgstr ""
+
+#: lib/ex_admin/view_helpers.ex:58
+msgid "New"
+msgstr ""
+
+#: lib/mix/tasks/admin.install.ex:142
+msgid "To add dashboard sections, checkout 'web/admin/dashboards.ex'"
+msgstr ""
+
+#: lib/mix/tasks/admin.install.ex:141
+msgid "Welcome to ExAdmin. This is the default dashboard page."
+msgstr ""
+
+#: web/templates/admin_resource/index.html.eex:7
+msgid "Welcome to Notifier"
+msgstr ""
+
+#: web/controllers/admin_resource_controller.ex:116
+msgid "invalid after_filter return:"
+msgstr ""
+
+#: web/controllers/admin_resource_controller.ex:281
+msgid "was successfully destroyed."
+msgstr ""
+
+#: web/controllers/admin_resource_controller.ex:255
+msgid "was successfully updated."
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/index.ex:126
+#: lib/ex_admin/themes/admin_lte2/index.ex:120
+msgid "Are you sure you want to delete these %{name}? You wont be able to undo this."
+msgstr ""
+
+#: lib/ex_admin/themes/admin_lte2/filter.ex:26
+msgid "Clear Filters"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/form.ex:245
+#: lib/ex_admin/themes/active_admin/index.ex:115
+#: lib/ex_admin/themes/admin_lte2/form.ex:238
+#: lib/ex_admin/themes/admin_lte2/index.ex:109
+msgid "Delete"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/filter.ex:22
+#: lib/ex_admin/themes/admin_lte2/filter.ex:25
+msgid "Filter"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/index.ex:111
+#: lib/ex_admin/themes/admin_lte2/index.ex:105
+msgid "View"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/index.ex:147
+#: lib/ex_admin/themes/admin_lte2/index.ex:141
+msgid "Delete Selected"
+msgstr ""
+
+#: web/controllers/admin_resource_controller.ex:238
+msgid "%{model_name} was successfully created."
+msgstr ""
+
+#: web/controllers/admin_association_controller.ex:57
+msgid "%{through_assoc} was successfully added."
+msgstr ""
+
+#: lib/ex_admin/utils.ex:272
+msgid "Are you sure you want to delete this?"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/form.ex:109
+#: lib/ex_admin/themes/admin_lte2/form.ex:100
+msgid "Cancel"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/form.ex:102
+#: lib/ex_admin/themes/admin_lte2/form.ex:97
+msgid "Create"
+msgstr ""
+
+#: lib/ex_admin/index.ex:347
+msgid "Download:"
+msgstr ""
+
+#: web/templates/themes/admin_lte2/layout/header.html.eex:25
+msgid "Logout"
+msgstr ""
+
+#: web/templates/themes/admin_lte2/layout/header.html.eex:22
+msgid "Profile"
+msgstr ""
+
+#: web/templates/themes/admin_lte2/layout/header.html.eex:47
+msgid "RESOURCES"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/form.ex:201
+#: lib/ex_admin/themes/admin_lte2/form.ex:188
+msgid "Remove"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/filter.ex:39
+#: lib/ex_admin/themes/admin_lte2/filter.ex:41
+msgid "Search %{name_label}"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/form.ex:102
+#: lib/ex_admin/themes/admin_lte2/form.ex:97
+msgid "Update"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/table.ex:20
+#: lib/ex_admin/themes/admin_lte2/table.ex:26
+msgid "%{resource_model} Details"
+msgstr ""
+
+#: lib/mix/tasks/admin.install.ex:140
+msgid "Dashboard"
+msgstr ""
+
+#: lib/ex_admin/paginate.ex:38
+msgid "Displaying"
+msgstr ""
+
+#: lib/ex_admin/paginate.ex:58
+msgid "Displaying "
+msgstr ""
+
+#: lib/ex_admin/paginate.ex:48
+msgid "Displaying %{name}"
+msgstr ""
+
+#: lib/ex_admin/filter.ex:11
+msgid "Equal To"
+msgstr ""
+
+#: lib/ex_admin/filter.ex:11
+msgid "Greater Than"
+msgstr ""
+
+#: lib/ex_admin/paginate.ex:68
+msgid "Last »"
+msgstr ""
+
+#: lib/ex_admin/filter.ex:11
+msgid "Less Than"
+msgstr ""
+
+#: lib/ex_admin/paginate.ex:67
+msgid "Next ›"
+msgstr ""
+
+#: lib/ex_admin/paginate.ex:59
+msgid "all %{total}"
+msgstr ""
+
+#: lib/ex_admin/paginate.ex:42 lib/ex_admin/paginate.ex:52
+msgid "in total"
+msgstr ""
+
+#: lib/ex_admin/paginate.ex:40 lib/ex_admin/paginate.ex:50
+msgid "of"
+msgstr ""
+
+#: lib/ex_admin/paginate.ex:65
+msgid "« First"
+msgstr ""
+
+#: lib/ex_admin/paginate.ex:66
+msgid "‹ Prev"
+msgstr ""
+
+#: lib/ex_admin/form/fields.ex:150
+msgid "Select %{nm}"
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/index.ex:29
+#: lib/ex_admin/themes/admin_lte2/index.ex:28
+msgid "No %{label} found."
+msgstr ""
+
+#: lib/ex_admin/themes/active_admin/index.ex:31
+#: lib/ex_admin/themes/admin_lte2/index.ex:30
+msgid "There are no %{label} yet. "
+msgstr ""
+
+#: lib/ex_admin/utils.ex:113
+msgid "a"
+msgstr ""
+
+#: lib/ex_admin/utils.ex:111
+msgid "an"
+msgstr ""

--- a/priv/gettext/fr_FR/LC_MESSAGES/default.po
+++ b/priv/gettext/fr_FR/LC_MESSAGES/default.po
@@ -1,0 +1,228 @@
+msgid ""
+msgstr ""
+"Language: fr_FR\n"
+
+#: web/controllers/admin_resource_controller.ex:303
+msgid "was successfully destroyed."
+msgid_plural "were successfully destroyed."
+msgstr[0] "a bien été supprimé(e)."
+msgstr[1] "ont bien été supprimé(e)s."
+
+#: web/templates/themes/admin_lte2/layout/header.html.eex:63
+msgid "ACTIONS"
+msgstr "ACTIONS"
+
+#: lib/ex_admin/themes/active_admin/index.ex:140
+#: lib/ex_admin/themes/admin_lte2/index.ex:134
+msgid "Batch Actions"
+msgstr "Actions groupées"
+
+#: lib/ex_admin/themes/active_admin/index.ex:33
+#: lib/ex_admin/themes/admin_lte2/index.ex:32
+msgid "Create one"
+msgstr "Créer un nouveau"
+
+#: lib/ex_admin/themes/active_admin/index.ex:113
+#: lib/ex_admin/themes/admin_lte2/index.ex:107 lib/ex_admin/view_helpers.ex:56
+msgid "Edit"
+msgstr "Editer"
+
+#: lib/ex_admin/themes/active_admin/filter.ex:14
+#: lib/ex_admin/themes/admin_lte2/filter.ex:15
+msgid "Filters"
+msgstr "Filtres"
+
+#: lib/ex_admin/view_helpers.ex:58
+msgid "New"
+msgstr "Nouveau"
+
+#: lib/mix/tasks/admin.install.ex:142
+msgid "To add dashboard sections, checkout 'web/admin/dashboards.ex'"
+msgstr "Pour ajouter des sections, utiliser 'web/admin/dashboards.ex'"
+
+#: lib/mix/tasks/admin.install.ex:141
+msgid "Welcome to ExAdmin. This is the default dashboard page."
+msgstr "Bienvenue à ExAdmin. Ceci est le tableau de bord par défaut."
+
+#: web/templates/admin_resource/index.html.eex:7
+msgid "Welcome to Notifier"
+msgstr "Bienvenue dans le Notificateur"
+
+#: web/controllers/admin_resource_controller.ex:116
+msgid "invalid after_filter return:"
+msgstr "Retour de after_filter invalide :"
+
+#: web/controllers/admin_resource_controller.ex:281
+msgid "was successfully destroyed."
+msgstr "a bien été supprimé(e)."
+
+#: web/controllers/admin_resource_controller.ex:255
+msgid "was successfully updated."
+msgstr "a bien été mis(e) à jour."
+
+#: lib/ex_admin/themes/active_admin/index.ex:126
+#: lib/ex_admin/themes/admin_lte2/index.ex:120
+msgid "Are you sure you want to delete these %{name}? You wont be able to undo this."
+msgstr "Voulez-vous vraiment supprimer tous ces %{name} ? Cette action ne pourra pas être annulée."
+
+#: lib/ex_admin/themes/admin_lte2/filter.ex:26
+msgid "Clear Filters"
+msgstr "Effacer les filtres"
+
+#: lib/ex_admin/themes/active_admin/form.ex:245
+#: lib/ex_admin/themes/active_admin/index.ex:115
+#: lib/ex_admin/themes/admin_lte2/form.ex:238
+#: lib/ex_admin/themes/admin_lte2/index.ex:109
+msgid "Delete"
+msgstr "Supprimer"
+
+#: lib/ex_admin/themes/active_admin/filter.ex:22
+#: lib/ex_admin/themes/admin_lte2/filter.ex:25
+msgid "Filter"
+msgstr "Filter"
+
+#: lib/ex_admin/themes/active_admin/index.ex:111
+#: lib/ex_admin/themes/admin_lte2/index.ex:105
+msgid "View"
+msgstr "Voir"
+
+#: lib/ex_admin/themes/active_admin/index.ex:147
+#: lib/ex_admin/themes/admin_lte2/index.ex:141
+msgid "Delete Selected"
+msgstr "Supprimer les éléments sélectionnés"
+
+#: web/controllers/admin_resource_controller.ex:238
+msgid "%{model_name} was successfully created."
+msgstr "%{model_name} a bien été créé(e)."
+
+#: web/controllers/admin_association_controller.ex:57
+msgid "%{through_assoc} was successfully added."
+msgstr "%{through_assoc} a bien été ajouté(e)."
+
+#: lib/ex_admin/utils.ex:272
+msgid "Are you sure you want to delete this?"
+msgstr "Voulez-vous vraiment supprimer ceci ?"
+
+#: lib/ex_admin/themes/active_admin/form.ex:109
+#: lib/ex_admin/themes/admin_lte2/form.ex:100
+msgid "Cancel"
+msgstr "Annuler"
+
+#: lib/ex_admin/themes/active_admin/form.ex:102
+#: lib/ex_admin/themes/admin_lte2/form.ex:97
+msgid "Create"
+msgstr "Créer"
+
+#: lib/ex_admin/index.ex:347
+msgid "Download:"
+msgstr "Télécharger :"
+
+#: web/templates/themes/admin_lte2/layout/header.html.eex:25
+msgid "Logout"
+msgstr "Se déconnecter"
+
+#: web/templates/themes/admin_lte2/layout/header.html.eex:22
+msgid "Profile"
+msgstr "Profil"
+
+#: web/templates/themes/admin_lte2/layout/header.html.eex:47
+msgid "RESOURCES"
+msgstr "RESSOURCES"
+
+#: lib/ex_admin/themes/active_admin/form.ex:201
+#: lib/ex_admin/themes/admin_lte2/form.ex:188
+msgid "Remove"
+msgstr "Retirer"
+
+#: lib/ex_admin/themes/active_admin/filter.ex:39
+#: lib/ex_admin/themes/admin_lte2/filter.ex:41
+msgid "Search %{name_label}"
+msgstr "Rechercher %{name_label}"
+
+#: lib/ex_admin/themes/active_admin/form.ex:102
+#: lib/ex_admin/themes/admin_lte2/form.ex:97
+msgid "Update"
+msgstr "Mettre à jour"
+
+#: lib/ex_admin/themes/active_admin/table.ex:20
+#: lib/ex_admin/themes/admin_lte2/table.ex:26
+msgid "%{resource_model} Details"
+msgstr "Détails de %{resource_model}"
+
+#: lib/mix/tasks/admin.install.ex:140
+msgid "Dashboard"
+msgstr "Tableau de bord"
+
+#: lib/ex_admin/paginate.ex:38
+msgid "Displaying"
+msgstr "Affichage"
+
+#: lib/ex_admin/paginate.ex:58
+msgid "Displaying "
+msgstr "Affichage"
+
+#: lib/ex_admin/paginate.ex:48
+msgid "Displaying %{name}"
+msgstr "Affichage des %{name}"
+
+#: lib/ex_admin/filter.ex:11
+msgid "Equal To"
+msgstr "Egal à"
+
+#: lib/ex_admin/filter.ex:11
+msgid "Greater Than"
+msgstr "Supérieur à"
+
+#: lib/ex_admin/paginate.ex:68
+msgid "Last »"
+msgstr "Dernières »"
+
+#: lib/ex_admin/filter.ex:11
+msgid "Less Than"
+msgstr "Inférieur à"
+
+#: lib/ex_admin/paginate.ex:67
+msgid "Next ›"
+msgstr "Suivantes ›"
+
+#: lib/ex_admin/paginate.ex:59
+msgid "all %{total}"
+msgstr "Tous les %{total}"
+
+#: lib/ex_admin/paginate.ex:42 lib/ex_admin/paginate.ex:52
+msgid "in total"
+msgstr "au total"
+
+#: lib/ex_admin/paginate.ex:40 lib/ex_admin/paginate.ex:50
+msgid "of"
+msgstr "sur"
+
+#: lib/ex_admin/paginate.ex:65
+msgid "« First"
+msgstr "« Premières"
+
+#: lib/ex_admin/paginate.ex:66
+msgid "‹ Prev"
+msgstr "‹ Précédentes"
+
+#: lib/ex_admin/form/fields.ex:150
+msgid "Select %{nm}"
+msgstr "Sélectionner %{nm}"
+
+#: lib/ex_admin/themes/active_admin/index.ex:29
+#: lib/ex_admin/themes/admin_lte2/index.ex:28
+msgid "No %{label} found."
+msgstr "Aucun(e) %{label} trouvé(e)."
+
+#: lib/ex_admin/themes/active_admin/index.ex:31
+#: lib/ex_admin/themes/admin_lte2/index.ex:30
+msgid "There are no %{label} yet. "
+msgstr "Il n'y a pas encore de %{label}"
+
+#: lib/ex_admin/utils.ex:113
+msgid "a"
+msgstr "un(e)"
+
+#: lib/ex_admin/utils.ex:111
+msgid "an"
+msgstr "un(e)"

--- a/priv/gettext/fr_FR/LC_MESSAGES/default.po
+++ b/priv/gettext/fr_FR/LC_MESSAGES/default.po
@@ -117,6 +117,7 @@ msgstr "Créer"
 msgid "Download:"
 msgstr "Télécharger :"
 
+#: web/templates/themes/active_admin/layout/header.html.eex:11
 #: web/templates/themes/admin_lte2/layout/header.html.eex:25
 msgid "Logout"
 msgstr "Se déconnecter"

--- a/priv/templates/admin.install/dashboard.exs
+++ b/priv/templates/admin.install/dashboard.exs
@@ -2,12 +2,12 @@ defmodule <%= base %>.ExAdmin.Dashboard do
   use ExAdmin.Register
 
   register_page "Dashboard" do
-    menu priority: 1, label: "Dashboard"
+    menu priority: 1, label: "<%= title_txt %>"
     content do
       div ".blank_slate_container#dashboard_default_message" do
         span ".blank_slate" do
-          span "Welcome to ExAdmin. This is the default dashboard page."
-          small "To add dashboard sections, checkout 'web/admin/dashboards.ex'"
+          span "<%= welcome_txt %>"
+          small "<%= add_txt %>"
         end
       end
     end

--- a/web/controllers/admin_association_controller.ex
+++ b/web/controllers/admin_association_controller.ex
@@ -1,6 +1,7 @@
 defmodule ExAdmin.AdminAssociationController do
   @moduledoc false
   use ExAdmin.Web, :controller
+  import ExAdmin.Gettext
   require Logger
 
   def action(conn, _options) do
@@ -53,7 +54,7 @@ defmodule ExAdmin.AdminAssociationController do
     end)
 
     conn
-    |> put_flash(:notice, "#{through_assoc} was successfully added")
+    |> put_flash(:notice, (gettext "%{through_assoc} was successfully added.", through_assoc: through_assoc))
     |> redirect(to: ExAdmin.Utils.admin_resource_path(resource, :show))
   end
 

--- a/web/controllers/admin_resource_controller.ex
+++ b/web/controllers/admin_resource_controller.ex
@@ -4,7 +4,7 @@ defmodule ExAdmin.AdminResourceController do
   require Logger
   import ExAdmin.Utils
   import ExAdmin.ParamsToAtoms
-  import ExAdmin.Utils
+  import ExAdmin.Gettext
   alias ExAdmin.Authorization
 
   plug :set_theme
@@ -113,7 +113,7 @@ defmodule ExAdmin.AdminResourceController do
         {_, _, _} = tuple -> tuple
         %Plug.Conn{} = conn -> {conn, params, resource}
         error ->
-          raise ExAdmin.RuntimeError, message: "invalid after_filter return: #{inspect error}"
+          raise ExAdmin.RuntimeError, message: (gettext "invalid after_filter return:") <> " #{inspect error}"
       end
     else
       {conn, params, resource}
@@ -235,7 +235,7 @@ defmodule ExAdmin.AdminResourceController do
         conn |> handle_changeset_error(defn, changeset, params)
       resource ->
         {conn, _, resource} = handle_after_filter(conn, :create, defn, params, resource)
-        put_flash(conn, :notice, "#{base_name model} was successfully created.")
+        put_flash(conn, :notice, (gettext "%{model_name} was successfully created.", model_name: (base_name model) ))
         |> redirect(to: admin_resource_path(resource, :show))
     end
   end
@@ -252,7 +252,7 @@ defmodule ExAdmin.AdminResourceController do
         conn |> handle_changeset_error(defn, changeset, params)
       resource ->
         {conn, _, resource} = handle_after_filter(conn, :update, defn, params, resource)
-        put_flash(conn, :notice, "#{base_name model} was successfully updated")
+        put_flash(conn, :notice, "#{base_name model} " <> (gettext "was successfully updated."))
         |> redirect(to: admin_resource_path(resource, :show))
     end
   end
@@ -278,7 +278,7 @@ defmodule ExAdmin.AdminResourceController do
     if conn.assigns.xhr do
       render conn, "destroy.js", tr_id: String.downcase("#{model_name}_#{params[:id]}")
     else
-      put_flash(conn, :notice, "#{model_name} was successfully destroyed.")
+      put_flash(conn, :notice, "#{model_name} " <> (gettext "was successfully destroyed."))
       |> redirect(to: admin_resource_path(defn.resource_model, :index))
     end
   end
@@ -299,7 +299,8 @@ defmodule ExAdmin.AdminResourceController do
       repo.delete repo.get(resource_model, id)
     end)
 
-    put_flash(conn, :notice, "Successfully destroyed #{count} #{pluralize params[:resource], count}")
+    put_flash(conn, :notice, "#{count} #{pluralize params[:resource], count} "
+              <> (ngettext "was successfully destroyed.", "were successfully destroyed.", count))
     |> redirect(to: admin_resource_path(resource_model, :index))
   end
 

--- a/web/templates/admin_resource/index.html.eex
+++ b/web/templates/admin_resource/index.html.eex
@@ -4,7 +4,7 @@
     <div class="panel">
       <h3>Info</h3>
       <div class="panel_contents">
-        <p><% gettext "Welcome to Notifier" %></p>
+        <p><%= gettext "Welcome to Notifier" %></p>
       </div>
     </div>
   </div>

--- a/web/templates/admin_resource/index.html.eex
+++ b/web/templates/admin_resource/index.html.eex
@@ -1,9 +1,10 @@
+<% import ExAdmin.Gettext %>
 <div class="columns">
   <div class="column" style="width: 49.0%; margin-right: 2%;">
     <div class="panel">
       <h3>Info</h3>
       <div class="panel_contents">
-        <p>Welcome to Notifier</p>
+        <p><% gettext "Welcome to Notifier" %></p>
       </div>
     </div>
   </div>

--- a/web/templates/themes/active_admin/layout/header.html.eex
+++ b/web/templates/themes/active_admin/layout/header.html.eex
@@ -1,3 +1,4 @@
+<% import ExAdmin.Gettext %>
 <div class="header" id="header">
   <h1 class="site_title" id="site_title"><%= ExAdmin.LayoutView.logo_full %></h1>
   <ul class="header-item" id="tabs">
@@ -7,7 +8,7 @@
   <%= if use_authentication?(@conn) do %>
     <p class="header-item" id="utility_nav">
       <span class="current_user"><%= current_user_name(@conn) %></span>
-      <%= Phoenix.HTML.Link.link "Logout", to: session_path(@conn, :destroy), "data-method": "delete", "data-csrf": Plug.CSRFProtection.get_csrf_token, rel: "nofollow" %>
+      <%= Phoenix.HTML.Link.link (gettext "Logout"), to: session_path(@conn, :destroy), "data-method": "delete", "data-csrf": Plug.CSRFProtection.get_csrf_token, rel: "nofollow" %>
     </p>
   <% end %>
 </div>

--- a/web/templates/themes/admin_lte2/layout/header.html.eex
+++ b/web/templates/themes/admin_lte2/layout/header.html.eex
@@ -44,7 +44,7 @@
   <section class="sidebar">
     <!-- Sidebar Menu -->
     <ul class="sidebar-menu">
-      <li class="header"><% gettext "RESOURCES" %></li>
+      <li class="header"><%= gettext "RESOURCES" %></li>
       <!-- Optionally, you can add icons to the links -->
       <%# <li class="active"><a href="#"><i class="fa fa-dashboard"></i> <span>Dashboard</span></a></li> %>
       <%= if Application.get_env(:ex_admin, :nest_resources, false) do %>
@@ -60,7 +60,7 @@
 
       <% actions = ExAdmin.get_title_actions(@conn) %>
       <%= if any_actions?(actions) do %>
-        <li class="header"><% gettext "ACTIONS" %></li>
+        <li class="header"><%= gettext "ACTIONS" %></li>
         <%= for {action, opts} <- actions do %>
           <li>
             <% opts = build_menu_icon(opts) %>

--- a/web/templates/themes/admin_lte2/layout/header.html.eex
+++ b/web/templates/themes/admin_lte2/layout/header.html.eex
@@ -1,3 +1,4 @@
+<% import ExAdmin.Gettext %>
 <header class="main-header" id="header">
   <a href="#" class="logo">
     <span class="logo-mini"><%= ExAdmin.LayoutView.logo_mini %></span>
@@ -18,10 +19,10 @@
             </a>
             <ul class="dropdown-menu" role="menu">
               <li>
-                <%= Phoenix.HTML.Link.link "Profile", to: ExAdmin.Utils.admin_resource_path(current_user(@conn)) %>
+                <%= Phoenix.HTML.Link.link (gettext "Profile"), to: ExAdmin.Utils.admin_resource_path(current_user(@conn)) %>
               </li>
               <li>
-                <%= Phoenix.HTML.Link.link "Logout", to: session_path(@conn, :destroy), "data-method": "delete", "data-csrf": Plug.CSRFProtection.get_csrf_token, rel: "nofollow" %>
+                <%= Phoenix.HTML.Link.link (gettext "Logout"), to: session_path(@conn, :destroy), "data-method": "delete", "data-csrf": Plug.CSRFProtection.get_csrf_token, rel: "nofollow" %>
               </li>
             </ul>
           </li>
@@ -43,7 +44,7 @@
   <section class="sidebar">
     <!-- Sidebar Menu -->
     <ul class="sidebar-menu">
-      <li class="header">RESOURCES</li>
+      <li class="header"><% gettext "RESOURCES" %></li>
       <!-- Optionally, you can add icons to the links -->
       <%# <li class="active"><a href="#"><i class="fa fa-dashboard"></i> <span>Dashboard</span></a></li> %>
       <%= if Application.get_env(:ex_admin, :nest_resources, false) do %>
@@ -59,7 +60,7 @@
 
       <% actions = ExAdmin.get_title_actions(@conn) %>
       <%= if any_actions?(actions) do %>
-        <li class="header">ACTIONS</li>
+        <li class="header"><% gettext "ACTIONS" %></li>
         <%= for {action, opts} <- actions do %>
           <li>
             <% opts = build_menu_icon(opts) %>


### PR DESCRIPTION
In reference to #136, a  first attempt to bring i18n support, using Gettext.
Issues :
- No error messages translation (don't need those, in my case)
- No javascript strings translation (I don't know how to do this, perhaps generate the js files from Elixir so we could leverage Gettext ?)
- This a WIP, there could be some errors, some untranslated strings left...etc. ;-)

The .pot file is in priv/gettext, a french .po file is provided.
To test, add the following your app config.exs :
```
config :ex_admin, ExAdmin.Gettext,
  default_locale: "fr_FR"
```




