### PR TITLE
Fix README instructions for .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,15 @@ lib/my_app/endpoint.ex
 
 ```
 
-Add `!priv/static/themes` to .gitignore to  Track `priv/static/themes` directory
+Remove or comment `priv/static` in .gitignore to  track `priv/static` directory
 
 .gitignore
 ```
 ...
-!priv/static/themes
+# Since we are building assets from web/static,
+# we ignore priv/static. You may want to comment
+# this depending on your deployment strategy.
+# /priv/static/
 ```
 
 Start the application with `iex -S mix phoenix.server`


### PR DESCRIPTION
I updated the README instructions to comment or remove `priv/static` in .gitignore.  Rather than using `!priv/static` I recommend removing or commenting since the Phoenix generator already mentions it.  

.gitignore
~~~~
....
# Since we are building assets from web/static,
# we ignore priv/static. You may want to comment
# this depending on your deployment strategy.
/priv/static/
~~~~

The README currently says to add `!priv/static/themes`, but mix admin.install doesn't generate files into that folder.  