### PR TITLE
Remove hardcoded scripts from layout

### DIFF
--- a/lib/ex_admin/ex_admin.ex
+++ b/lib/ex_admin/ex_admin.ex
@@ -98,14 +98,24 @@ defmodule ExAdmin do
 
   For example:
 
-      # file web/templates/admin/admin_layout.html.eex
-      <link rel="stylesheet" href="<%= static_path(@conn, "/css/admin_custom.css") %>">
+  in `web/templates/admin/admin_layout.html.eex`
+  ```html
+  <link rel='stylesheet' href='<%= static_path(@conn, "/css/admin_custom.css") %>'>
 
-      # file priv/static/css/admin_custom.css
-      .foo {
-        color: green !important;
-        font-weight: 600;
-      }
+  <!--
+    since this is rendered into the head area, make sure to defer the loading
+    of your scripts with `async` to not block rendering.
+  -->
+  <script async src='<%= static_path(@conn, "/js/app.js") %>'></script>
+  ```
+
+  in `priv/static/css/admin_custom.css`
+  ```css
+  .foo {
+    color: green !important;
+    font-weight: 600;
+  }
+  ```
 
   """
   require Logger

--- a/web/templates/layout/active_admin.html.eex
+++ b/web/templates/layout/active_admin.html.eex
@@ -53,8 +53,6 @@
       </div>
     </body>
     <script src='<%= static_path(@conn, "/js/ex_admin_common.js") %>'></script>
-    <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
-    <script>require("web/static/js/app")</script>
     <script type="text/javascript">
       $(function() {
         $('#theme-selector').change(function(e) {

--- a/web/templates/layout/admin_lte2.html.eex
+++ b/web/templates/layout/admin_lte2.html.eex
@@ -74,8 +74,6 @@
     <script src='<%= static_path(@conn, "/js/ex_admin_common.js") %>'></script>
     <script src='<%= static_path(@conn, "/js/admin_lte2.js") %>'></script>
   </body>
-  <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
-
   <script type="text/javascript">
     $(function() {
       $('.theme-selector').on('click', function(e) {


### PR DESCRIPTION
* add example for including an actual script tag in the head

Originally I wanted to add another config to include custom scripts (like the head template) in order to not block site rendering. However as [Google](https://developers.google.com/speed/docs/insights/BlockingJS) is suggesting nowadays yuo should go back to put them into the head (for earlier parsing) and mark them as `async` (for making them non-blocking). 

TL;DR: Just removed the static `<script>` tag and `require` statement and added some docs