### PR TITLE
fixed issue with struct keys getting converted to strings

### DIFF
--- a/lib/ex_admin/repo.ex
+++ b/lib/ex_admin/repo.ex
@@ -356,9 +356,13 @@ res
   end
 
   def param_stringify_keys(params) when is_map(params) do
-    Map.to_list(params)
-    |> Enum.map(fn {key, value} -> {stringify_key(key), param_stringify_keys(value)} end)
-    |> Enum.into(%{})
+    if Map.has_key?(params, :__struct__) do
+      params
+    else
+      Map.to_list(params)
+      |> Enum.map(fn {key, value} -> {stringify_key(key), param_stringify_keys(value)} end)
+      |> Enum.into(%{})
+    end
   end
   def param_stringify_keys(params), do: params
 


### PR DESCRIPTION
This is a small fix for an issue where struct keys (such as %Plug.Upload{}) are being stringified when used as params in a changeset.