### PR TITLE
Fix form has_many

### DIFF
--- a/lib/ex_admin/repo.ex
+++ b/lib/ex_admin/repo.ex
@@ -326,6 +326,8 @@ res
   def get_assoc_join_model(resource, field) do
     res_model = resource.__struct__
     case res_model.__schema__(:association, field) do
+      %Ecto.Association.Has{queryable: queryable} ->
+        {:ok, queryable}
       %{through: [first, second]} ->
         {:ok, {res_model.__schema__(:association, first).related, second}}
       _ ->
@@ -340,6 +342,8 @@ res
     case get_assoc_join_model(resource, field) do
       {:ok, {assoc, second}} ->
         {assoc.__schema__(:association, second).related, assoc}
+      {:ok, assoc_model} ->
+        {assoc_model, field}
       error ->
         error
     end


### PR DESCRIPTION
An error was thrown with admin_lte2 when using "has_many" in a form. `ExAdmin.Repo` would handle only `through` relations.