### PR TITLE
Refactored authorization to perform check after resource loading

### DIFF
--- a/web/controllers/admin_resource_controller.ex
+++ b/web/controllers/admin_resource_controller.ex
@@ -1,5 +1,8 @@
 defmodule ExAdmin.AdminResourceController do
   @moduledoc false
+  # extract resource name from URL
+  @resource nil
+
   use ExAdmin.Web, :resource_controller
 
   def index(conn, defn, params) do


### PR DESCRIPTION
ACL rules could be based on the resource attributes, like 
`current_user.company_id == document.company_id`
So, `conn.assigns.resource` should be loaded before authorization check.
