### PR TITLE
Added support of hint option for form elements

### DIFF
--- a/lib/ex_admin/form.ex
+++ b/lib/ex_admin/form.ex
@@ -649,7 +649,7 @@ defmodule ExAdmin.Form do
         else
           input_collection(resource, collection, model_name, field_name, nil, nil, item, conn.params, error)
         end
-        build_errors(errors)
+        build_errors(errors, item[:opts][:hint])
       end
     end)
 
@@ -726,7 +726,7 @@ defmodule ExAdmin.Form do
       field_type = opts[:type] || field_type(resource, field_name)
       [
         build_control(field_type, resource, opts, model_name, field_name, ext_name),
-        build_errors(errors)
+        build_errors(errors, opts[:hint])
       ]
     end)
     html
@@ -811,7 +811,7 @@ defmodule ExAdmin.Form do
             end
           end
         end
-        build_errors(errors)
+        build_errors(errors, opts[:hint])
       end
     end
   end
@@ -1242,8 +1242,11 @@ defmodule ExAdmin.Form do
   end
 
   @doc false
-  def build_errors(nil), do: nil
-  def build_errors(errors) do
+  def build_errors(nil, nil), do: nil
+  def build_errors(nil, hint) do
+    theme_module(Form).build_hint(hint)
+  end
+  def build_errors(errors, _) do
     for error <- errors do
       theme_module(Form).build_form_error(error)
     end

--- a/lib/ex_admin/themes/active_admin/form.ex
+++ b/lib/ex_admin/themes/active_admin/form.ex
@@ -112,7 +112,9 @@ defmodule ExAdmin.Theme.ActiveAdmin.Form do
     end
   end
 
-
+  def build_hint(hint) do
+    p ".inline #{hint}"
+  end
   def build_form_error(error) do
     p ".inline-errors #{error_messages error}"
   end
@@ -225,7 +227,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Form do
                     end
                   end
                 end
-                build_errors(errors)
+                build_errors(errors, field[:opts][:hint])
               end
             _ ->
               li ".string.input.stringish#{error}", id: "#{ext_name}_#{f_name}_input"  do
@@ -236,7 +238,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Form do
                 val = if res, do: [value: Map.get(res, f_name, "") |> escape_value], else: []
                 Xain.input([type: :text, maxlength: "255", id: "#{ext_name}_#{f_name}",
                   name: name, required: true] ++ val)
-                build_errors(errors)
+                build_errors(errors, field[:opts][:hint])
               end
           end
         end

--- a/lib/ex_admin/themes/admin_lte2/form.ex
+++ b/lib/ex_admin/themes/admin_lte2/form.ex
@@ -101,6 +101,12 @@ defmodule ExAdmin.Theme.AdminLte2.Form do
     end
   end
 
+  def build_hint(hint) do
+    span ".control-label" do
+      i ".fa.fa-info-circle"
+      text " #{hint}"
+    end
+  end
   def build_form_error(error) do
     label ".control-label" do
       i ".fa.fa-times-circle-o"
@@ -215,7 +221,7 @@ defmodule ExAdmin.Theme.AdminLte2.Form do
                       end
                     end
                   end
-                  build_errors(errors)
+                  build_errors(errors, field[:opts][:hint])
                 end
               end
             _ ->
@@ -228,7 +234,7 @@ defmodule ExAdmin.Theme.AdminLte2.Form do
                   val = if res, do: [value: Map.get(res, f_name, "") |> escape_value], else: []
                   Xain.input([type: :text, maxlength: "255", id: "#{ext_name}_#{f_name}",
                     class: "form-control", name: name] ++ val)
-                  build_errors(errors)
+                  build_errors(errors, field[:opts][:hint])
                 end
               end
           end


### PR DESCRIPTION
With this feature you could specify hint for input inside `form` macro:

``` elixir
form client do
  inputs do
    # ..
    input client, :description, hint: "Enter something descriptive"
  end
end
```

to get something like that:

![](https://api.monosnap.com/rpc/file/download?id=uJeoUzfIEWxZJZIeu7znUNVgLseQkd)
