### PR TITLE
Dispatch ExAdmin.Authorization by resource instead of defn

### DIFF
--- a/lib/ex_admin/authentication.ex
+++ b/lib/ex_admin/authentication.ex
@@ -15,12 +15,11 @@ end
 
 defprotocol ExAdmin.Authorization do
   @fallback_to_any true
-  def authorize_query(defn, conn, query, action, id)
-  def authorize_action(defn, conn, action)
+  def authorize_query(resource, conn, query, action, id)
+  def authorize_action(resource, conn, action)
 end
 
 defimpl ExAdmin.Authorization, for: Any do
   def authorize_query(_, _, query, _, _), do: query
   def authorize_action(_, _, _), do: true
 end
-

--- a/lib/ex_admin/ex_admin.ex
+++ b/lib/ex_admin/ex_admin.ex
@@ -244,14 +244,14 @@ defmodule ExAdmin do
   end
 
   @doc false
-  def default_resource_title_actions(%Plug.Conn{params: params} = conn, %{resource_model: _resource_model} = defn) do
+  def default_resource_title_actions(%Plug.Conn{params: params} = conn, %{resource_model: resource_model} = defn) do
     singular = ExAdmin.Utils.displayable_name_singular(conn) |> titleize
     actions = defn.actions
     case Utils.action_name(conn) do
       :show ->
         id = Map.get(params, "id")
         Enum.reduce([:edit, :new, :delete], [], fn(action, acc) ->
-          if Utils.authorized_action?(conn, action, defn) do
+          if Utils.authorized_action?(conn, action, resource_model) do
             [{action, action_button(conn, defn, singular, :show, action, actions, id)}|acc]
           else
             acc
@@ -260,7 +260,7 @@ defmodule ExAdmin do
         |> add_custom_actions(:show, actions, id)
         |> Enum.reverse
       action when action in [:index, :edit] ->
-        if Utils.authorized_action?(conn, action, defn) do
+        if Utils.authorized_action?(conn, action, resource_model) do
           [{action, action_button(conn, defn, singular, action, :new, actions)}]
         else
           []

--- a/lib/ex_admin/helpers.ex
+++ b/lib/ex_admin/helpers.ex
@@ -61,7 +61,7 @@ defmodule ExAdmin.Helpers do
   end
 
   defp build_content_link(link?, conn, resource, contents) do
-    if link? && ExAdmin.Utils.authorized_action?(conn, :show) do
+    if link? && ExAdmin.Utils.authorized_action?(conn, :show, resource) do
       path = admin_resource_path resource, :show
       "<a href='#{path}'>#{contents}</a>"
     else

--- a/lib/ex_admin/index.ex
+++ b/lib/ex_admin/index.ex
@@ -404,9 +404,9 @@ defmodule ExAdmin.Index do
   end
 
   @doc false
-  def get_authorized_links(conn, links, _resource_model) do
+  def get_authorized_links(conn, links, resource_model) do
     Enum.reduce links, [], fn(item, acc) ->
-      if ExAdmin.Utils.authorized_action?(conn, item), do: [item | acc], else: acc
+      if ExAdmin.Utils.authorized_action?(conn, item, resource_model), do: [item | acc], else: acc
     end
   end
 end

--- a/lib/ex_admin/navigation.ex
+++ b/lib/ex_admin/navigation.ex
@@ -16,6 +16,7 @@ defmodule ExAdmin.Navigation do
         fun -> fun.(conn)
       end
     end)
+    |> Enum.filter(fn(defn) -> ExAdmin.Utils.authorized_action?(conn, :index, defn) end)
     |> Enum.sort(fn(%{menu: menu1}, %{menu: menu2}) ->
       menu1[:priority] < menu2[:priority]
     end)

--- a/lib/ex_admin/utils.ex
+++ b/lib/ex_admin/utils.ex
@@ -333,15 +333,17 @@ defmodule ExAdmin.Utils do
   def authorized_action?(conn, action, resource_model) when is_atom(resource_model) do
     # fun = Application.get_env(:ex_admin, :authorize)
     # if fun, do: fun.(conn, action, resource_model), else: true
-    authorized_action? conn, action, conn.assigns[:defn]
+    authorized_action? conn, action, resource_model.__struct__
   end
-  def authorized_action?(conn, action, defn) do
-    # authorized_action?(conn, action, defn.resource_model)
-    ExAdmin.Authorization.authorize_action(defn, conn, action)
+  def authorized_action?(conn, action, %{resource_model: resource_model}) do
+    authorized_action?(conn, action, resource_model)
   end
-  def authorized_action?(conn, action) do
-    ExAdmin.Authorization.authorize_action(conn.assigns[:defn], conn, action)
+  def authorized_action?(conn, action, resource) do
+    ExAdmin.Authorization.authorize_action(resource, conn, action)
   end
+  #def authorized_action?(conn, action) do
+  #  ExAdmin.Authorization.authorize_action(conn.assigns[:defn], conn, action)
+  #end
 
   @doc false
   def use_authentication do

--- a/web/controllers/admin_resource_controller.ex
+++ b/web/controllers/admin_resource_controller.ex
@@ -12,7 +12,7 @@ defmodule ExAdmin.AdminResourceController do
       nil ->
         id = params |> Map.to_list
         query = model.run_query(repo, defn, :index, id)
-        Authorization.authorize_query(defn, conn, query, :index, id)
+        Authorization.authorize_query(conn.assigns.resource, conn, query, :index, id)
         |> ExAdmin.Query.execute_query(repo, :index, id)
 
       page ->
@@ -164,7 +164,7 @@ defmodule ExAdmin.AdminResourceController do
 
     id = params |> Map.to_list
     query = model.run_query(repo, defn, :csv, id)
-    csv = Authorization.authorize_query(defn, conn, query, :csv, id)
+    csv = Authorization.authorize_query(conn.assigns.resource, conn, query, :csv, id)
     |> ExAdmin.Query.execute_query(repo, :csv, id)
     |> case  do
       [] -> []

--- a/web/ex_admin/resource_controller.ex
+++ b/web/ex_admin/resource_controller.ex
@@ -65,7 +65,7 @@ defmodule ExAdmin.ResourceController do
       end
 
       def authorize_action(conn, action) do
-        if ExAdmin.Authorization.authorize_action(conn.assigns[:defn], conn, action) do
+        if ExAdmin.Authorization.authorize_action(conn.assigns[:resource], conn, action) do
           conn
         else
           render_403(conn)
@@ -89,7 +89,7 @@ defmodule ExAdmin.ResourceController do
         model = defn.__struct__
         query = model.run_query(repo, defn, action, resource_id)
         resource =
-        Authorization.authorize_query(defn, conn, query, action, resource_id)
+        Authorization.authorize_query(defn.resource_model.__struct__, conn, query, action, resource_id)
         |> ExAdmin.Query.execute_query(repo, action, resource_id)
 
         if resource == nil do


### PR DESCRIPTION
If possible dispatching by resource should be used to provide more precise information to ACL rules.
In cases when there is no resource (like ExAdmin.Dashboard) - fallback to dispatching by defn will be used.