### PR TITLE
The default new/edit forms should take into the account the changeset…

### DIFF
--- a/lib/ex_admin/changeset.ex
+++ b/lib/ex_admin/changeset.ex
@@ -1,13 +1,16 @@
 defmodule ExAdmin.Changeset do
   @moduledoc false
   alias __MODULE__, as: Cs
-  defstruct valid?: true, changeset: nil, errors: nil, dependents: []
+  defstruct valid?: true, changeset: nil, errors: nil, dependents: [], required: []
 
   def update(%Cs{} = r, items) when is_list(items) do
     Enum.reduce(items, r, fn({k,v}, acc) -> update(acc, k, v) end)
   end
+  def update(%Cs{} = r, :changeset, nil) do
+    %Cs{r | changeset: nil, required: []}
+  end
   def update(%Cs{} = r, :changeset, changeset) do
-    %Cs{r | changeset: changeset}
+    %Cs{r | changeset: changeset, required: changeset.required}
   end
   def update(%Cs{valid?: valid?} = r, :valid?, value) do
     %Cs{r | valid?: valid? and value}

--- a/lib/ex_admin/register.ex
+++ b/lib/ex_admin/register.ex
@@ -445,8 +445,8 @@ defmodule ExAdmin.Register do
   The following example illustrates how to add a sync action that will
   be run before the index page is loaded.
 
-      changeset create: &__MODULE__.create_changeset/2,
-                update: &__MODULE__.update_changeset/2
+      changesets create: &__MODULE__.create_changeset/2,
+                 update: &__MODULE__.update_changeset/2
 
       def create_changeset(model, params) do
         Ecto.Changeset.cast(model, params, ~w(name password), ~w(age))

--- a/lib/ex_admin/view_helpers.ex
+++ b/lib/ex_admin/view_helpers.ex
@@ -68,6 +68,7 @@ defmodule ExAdmin.ViewHelpers do
     end
   end
 
+  def status_tag(nil), do: status_tag(false)
   def status_tag(status) do
     span ".status_tag.#{status} #{status}"
   end

--- a/web/controllers/admin_resource_controller.ex
+++ b/web/controllers/admin_resource_controller.ex
@@ -48,9 +48,13 @@ defmodule ExAdmin.AdminResourceController do
   end
 
   def edit(conn, defn, params) do
+    model = defn.__struct__
     resource = conn.assigns.resource
-    conn = Plug.Conn.assign(conn, :ea_required,
-       defn.resource_model.changeset(resource).required)
+
+    changeset_fn = model.changeset_fn(defn, :update)
+    changeset = ExAdmin.Repo.changeset(changeset_fn, resource, params[defn.resource_name])
+
+    conn = Plug.Conn.assign(conn, :ea_required, changeset.required)
     {conn, params, resource} = handle_after_filter(conn, :edit, defn, params, resource)
     contents = do_form_view(conn, resource, params)
 
@@ -58,9 +62,13 @@ defmodule ExAdmin.AdminResourceController do
   end
 
   def new(conn, defn, params) do
+    model = defn.__struct__
     resource = conn.assigns.resource
-    conn = Plug.Conn.assign(conn, :ea_required,
-       defn.resource_model.changeset(resource).required)
+
+    changeset_fn = model.changeset_fn(defn, :create)
+    changeset = ExAdmin.Repo.changeset(changeset_fn, resource, params[defn.resource_name])
+
+    conn = Plug.Conn.assign(conn, :ea_required, changeset.required)
     {conn, params, resource} = handle_after_filter(conn, :new, defn, params, resource)
     contents = do_form_view(conn, resource, params)
 


### PR DESCRIPTION
… options. Added `required` key to changeset. Correct documentation typo.

Fixes issue #221