### PR TITLE
Fetch required fields from the changeset itself

### DIFF
--- a/web/ex_admin/resource_controller.ex
+++ b/web/ex_admin/resource_controller.ex
@@ -39,8 +39,7 @@ defmodule ExAdmin.ResourceController do
       defp handle_changeset_error(conn, defn, changeset, params) do
         conn = put_flash(conn, :inline_error, changeset.errors)
         |> Plug.Conn.assign(:changeset, changeset)
-        |> Plug.Conn.assign(:ea_required,
-           defn.resource_model.changeset(conn.assigns.resource).required)
+        |> Plug.Conn.assign(:ea_required, changeset.required)
         contents = do_form_view(conn, ExAdmin.Changeset.get_data(changeset), params)
         render(conn, "admin.html", html: contents, filters: nil)
       end


### PR DESCRIPTION
This is throwing an exception when custom changeset functions are specified. I vaguely remember adding the `required` array key to `ExAdmin.Changeset`, and all tests pass for me with this change.

Thanks, Steve!