### PR TITLE
Fix class attribute quoting

### DIFF
--- a/web/templates/admin_resource/index.html.eex
+++ b/web/templates/admin_resource/index.html.eex
@@ -9,7 +9,7 @@
     </div>
   </div>
 
-  <div class="column style="width: 49.0%;">
+  <div class="column" style="width: 49.0%;">
     <div class="panel">
       <h3>News</h3>
       <div class="panel_contents">


### PR DESCRIPTION
Am seeing escaped html in my admin and noticed this missing quoted class attribute. Not sure if this is used but very minor change.