### PR TITLE
Fixes rendering of complex maps

### DIFF
--- a/lib/ex_admin/helpers.ex
+++ b/lib/ex_admin/helpers.ex
@@ -218,7 +218,8 @@ defmodule ExAdmin.Helpers do
   defp format_contents(%{__struct__: _} = contents), do: to_string(contents)
   defp format_contents(%{} = contents) do
     Enum.reduce(contents, [], fn {k,v}, acc ->
-      ["#{k}: #{v}" | acc]
+      value = ExAdmin.Render.to_string(v)
+      ["#{k}: #{value}" | acc]
     end)
     |> Enum.reverse
     |> Enum.join(", ")

--- a/lib/ex_admin/table.ex
+++ b/lib/ex_admin/table.ex
@@ -32,8 +32,9 @@ defmodule ExAdmin.Table do
                 _contents, {:map, f_name} ->
                   for {k,v} <- Map.get(resource, f_name) do
                     tr do
+                      value = ExAdmin.Render.to_string(v)
                       field_header "#{f_name} #{k}"
-                      td ".td-#{parameterize k} #{v}"
+                      td ".td-#{parameterize k} #{value}"
                     end
                   end
                 contents, f_name ->

--- a/test/helpers_test.exs
+++ b/test/helpers_test.exs
@@ -3,6 +3,7 @@ defmodule ExAdmin.HelpersTest do
   alias ExAdmin.Helpers
   alias TestExAdmin.Noid
   alias TestExAdmin.Simple
+  alias TestExAdmin.Maps
   use Xain
 
   test "build_field" do
@@ -32,6 +33,15 @@ defmodule ExAdmin.HelpersTest do
         ExAdmin.Table.handle_contents(contents, field_name)
       end)
     assert res == expected
+  end
+
+  test "build_field with complex map data" do
+    resource = %Maps{stats: %{list: [%{}]}}
+
+    res = Helpers.build_field(resource, %{}, {:stats, %{}}, fn(contents, field_name) ->
+        ExAdmin.Render.to_string(contents)
+      end)
+    assert res == ~s(list: [{}])
   end
 
   test "group_by" do


### PR DESCRIPTION
When given a `:map` structure that elixir's default implementation `to_string` can't handle, ex_admin would fail as well because the custom protocol was not being used

As a test case, you can see that the previous version failed to render
a model such as this:

```
%User{data: %{a_complex_list: [%{}]}
```

This would fail because `to_string([%{}])` also fails (you can easily
try that on an elixir console)

I also added a test that would fail with the previous version

This PR solves it by using the custom `ExAdmin.Render.to_string`
protocol instead.