### PR TITLE
Menu should support :none for registered resources

### DIFF
--- a/lib/ex_admin/register.ex
+++ b/lib/ex_admin/register.ex
@@ -148,7 +148,7 @@ defmodule ExAdmin.Register do
       end
 
       menu_opts = case Module.get_attribute(__MODULE__, :menu) do
-        :none ->
+        false ->
           %{none: true}
         nil ->
           %{ priority: 10,
@@ -520,7 +520,7 @@ defmodule ExAdmin.Register do
 
       # query_opts = Module.get_attribute(__MODULE__, :query)
       menu_opts = case Module.get_attribute(__MODULE__, :menu) do
-        :none ->
+        false ->
           %{none: true}
         nil ->
           %{label: page_name, priority: 99}
@@ -695,7 +695,7 @@ defmodule ExAdmin.Register do
 
   This example disables the menu item:
 
-      menu :none
+      menu false
 
   """
   defmacro menu(opts) do

--- a/lib/ex_admin/register.ex
+++ b/lib/ex_admin/register.ex
@@ -148,6 +148,8 @@ defmodule ExAdmin.Register do
       end
 
       menu_opts = case Module.get_attribute(__MODULE__, :menu) do
+        :none ->
+          %{none: true}
         nil ->
           %{ priority: 10,
              label: (base_name(module) |> Inflex.pluralize)}

--- a/lib/ex_admin/render.ex
+++ b/lib/ex_admin/render.ex
@@ -91,6 +91,15 @@ defimpl ExAdmin.Render, for: DateTime do
     |> Utils.format_datetime
   end
 end
+
+defimpl ExAdmin.Render, for: NaiveDateTime do
+  def to_string(dt) do
+    dt
+    |> NaiveDateTime.to_erl
+    |> ExAdmin.Utils.format_datetime
+  end
+end
+
 # defimpl ExAdmin.Render, for: Any do
 #   def to_string(data), do: "#{inspect data}"
 # end


### PR DESCRIPTION
Could we consider changing the API to `menu false`, so that it's consistent with other ExAdmin functions?