### PR TITLE
Fix dialyzer no_match warning

### DIFF
--- a/lib/ex_admin/index.ex
+++ b/lib/ex_admin/index.ex
@@ -144,7 +144,7 @@ defmodule ExAdmin.Index do
         opts = unquote(opts)
         unquote(contents)
 
-        selectable = case var!(selectable_column, ExAdmin.Index) do
+        selectable = case Macro.expand(var!(selectable_column, ExAdmin.Index), __ENV__) do
           nil -> false
           other -> other
         end


### PR DESCRIPTION
Before this change, the index macro was generating these warnings when
used:

lib/ex_admin/index.ex:149: The variable _@48 can never match since
previous clauses completely covered the type 'nil'
lib/ex_admin/index.ex:149: The variable _@18 can never match since
previous clauses completely covered the type 'nil'

The call to unquote(contents) could change the value of that variable,
but dialyzer isn't smart enough to realize that.