### PR TITLE
Use static_url instead of static_path

### DIFF
--- a/web/templates/layout/active_admin.html.eex
+++ b/web/templates/layout/active_admin.html.eex
@@ -10,10 +10,10 @@
     <meta name="csrf-token" id="_csrf_token" content="<%= Plug.CSRFProtection.get_csrf_token %>" />
     <%= favicon() %>
     <title><%= site_title() %></title>
-    <link rel="stylesheet" media="screen" type="text/css" href="<%= static_path(@conn, "/css/active_admin.css.css") %>">
+    <link rel="stylesheet" media="screen" type="text/css" href="<%= static_url(@conn, "/css/active_admin.css.css") %>">
 
     <!-- jQuery 2.1.4 & jquery-ui 1.11.4 -->
-    <script src="<%= static_path(@conn, "/js/jquery.min.js") %>"></script>
+    <script src="<%= static_url(@conn, "/js/jquery.min.js") %>"></script>
     <%=
       case Application.get_env(:ex_admin, :head_template) do
         {layout, template} ->
@@ -55,7 +55,7 @@
         </footer>
       </div>
     </body>
-    <script src='<%= static_path(@conn, "/js/ex_admin_common.js") %>'></script>
+    <script src='<%= static_url(@conn, "/js/ex_admin_common.js") %>'></script>
     <script type="text/javascript">
       $(function() {
         $('#theme-selector').change(function(e) {

--- a/web/templates/layout/admin_lte2.html.eex
+++ b/web/templates/layout/admin_lte2.html.eex
@@ -10,13 +10,13 @@
     <meta name="csrf-token" id="_csrf_token" content="<%= Plug.CSRFProtection.get_csrf_token %>" />
     <%= favicon() %>
     <title><%= site_title() %></title>
-    <link rel="stylesheet" href="<%= static_path(@conn, "/css/admin_lte2.css") %>">
+    <link rel="stylesheet" href="<%= static_url(@conn, "/css/admin_lte2.css") %>">
     <!-- Ionicons -->
     <%# <link rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css"> %>
     <!-- Theme style -->
 
     <!-- jQuery 2.1.4 & jquery-ui 1.11.4 -->
-    <script src="<%= static_path(@conn, "/js/jquery.min.js") %>"></script>
+    <script src="<%= static_url(@conn, "/js/jquery.min.js") %>"></script>
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -69,8 +69,8 @@
       $.widget.bridge('uibutton', $.ui.button);
     </script>
     <!-- Bootstrap 3.3.5 -->
-    <script src='<%= static_path(@conn, "/js/ex_admin_common.js") %>'></script>
-    <script src='<%= static_path(@conn, "/js/admin_lte2.js") %>'></script>
+    <script src='<%= static_url(@conn, "/js/ex_admin_common.js") %>'></script>
+    <script src='<%= static_url(@conn, "/js/admin_lte2.js") %>'></script>
   </body>
   <script type="text/javascript">
     $(function() {


### PR DESCRIPTION
If a consumer application uses an external `static_url` in its Phoenix.Endpoint configuration (to e.g. move all static assets served from `priv/static/` to a CDN), all calls to the `static_path` helper must be replaced with calls to the `static_url` helper to benefit from this.