### PR TITLE
Fixed pagination block update after entity delete

### DIFF
--- a/lib/ex_admin/index.ex
+++ b/lib/ex_admin/index.ex
@@ -324,7 +324,7 @@ defmodule ExAdmin.Index do
     columns = if custom_actions_column? || Enum.empty?(actions) do
       columns
     else
-      columns ++ [{"Actions", %{fun: fn(resource) -> build_index_links(conn, resource, actions) end,
+        columns ++ [{"Actions", %{fun: fn(resource) -> build_index_links(conn, resource, actions, page.page_number) end,
                                 label: ExAdmin.Gettext.gettext("Actions") }}]
     end
     opts = Map.put opts, :column_list, columns
@@ -393,7 +393,7 @@ defmodule ExAdmin.Index do
   end
 
   @doc false
-  def build_index_links(conn, resource, actions) do
+  def build_index_links(conn, resource, actions, page_num \\ 1) do
     resource_model = resource.__struct__
 
     links = case actions do
@@ -404,7 +404,7 @@ defmodule ExAdmin.Index do
     list = get_authorized_links(conn, links, resource_model) |> Enum.reverse
     labels = conn.assigns.defn.action_labels
 
-    Module.concat(conn.assigns.theme, Index).handle_action_links(list, resource, labels)
+    Module.concat(conn.assigns.theme, Index).handle_action_links(list, resource, labels, page_num)
   end
 
   @doc false

--- a/lib/ex_admin/themes/active_admin/index.ex
+++ b/lib/ex_admin/themes/active_admin/index.ex
@@ -103,7 +103,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Index do
     end
   end
 
-  def handle_action_links(list, resource, labels)  do
+  def handle_action_links(list, resource, labels, page_num)  do
     base_class = "member_link"
     list
     |> Enum.reduce([], fn(item, acc) ->
@@ -120,7 +120,8 @@ defmodule ExAdmin.Theme.ActiveAdmin.Index do
           a(link_text, href: admin_resource_path(resource, :destroy),
               class: base_class <> " delete_link", "data-confirm": confirm_message(),
               "data-remote": true,
-              "data-method": :delete, rel: :nofollow, title: link_text)
+              "data-method": :delete,
+              "data-params": "page="<>to_string(page_num), rel: :nofollow, title: link_text)
       end
       [link | acc]
     end)

--- a/lib/ex_admin/themes/admin_lte2/index.ex
+++ b/lib/ex_admin/themes/admin_lte2/index.ex
@@ -97,7 +97,7 @@ defmodule ExAdmin.Theme.AdminLte2.Index do
     end
   end
 
-  def handle_action_links(list, resource, labels)  do
+  def handle_action_links(list, resource, labels, page_num)  do
     base_class = "member_link"
     list
     |> Enum.reduce([], fn(item, acc) ->
@@ -114,7 +114,8 @@ defmodule ExAdmin.Theme.AdminLte2.Index do
           a(link_text, href: admin_resource_path(resource, :destroy),
               class: base_class <> " delete_link", "data-confirm": confirm_message(),
               "data-remote": true,
-              "data-method": :delete, rel: :nofollow, title: link_text)
+              "data-method": :delete,
+              "data-params": "page="<>to_string(page_num), rel: :nofollow, title: link_text)
       end
       [link | acc]
     end)

--- a/test/helpers_test.exs
+++ b/test/helpers_test.exs
@@ -24,7 +24,7 @@ defmodule ExAdmin.HelpersTest do
       "<a href='/admin/simples/1/edit' class='member_link edit_link' title='Edit'>Edit</a>" <>
       "<a href='/admin/simples/1' class='member_link delete_link'" <>
       " data-confirm='Are you sure you want to delete this?'" <>
-      " data-remote='true' data-method='delete' rel='nofollow' title='Delete'>Delete</a></td>"
+      " data-remote='true' data-method='delete' data-params='page=1' rel='nofollow' title='Delete'>Delete</a></td>"
 
     res = Helpers.build_field(resource, conn, {"Actions", %{fun: fn(res) ->
       ExAdmin.Index.build_index_links(conn, res, [:show, :edit, :delete])

--- a/web/templates/admin_resource/destroy.js.eex
+++ b/web/templates/admin_resource/destroy.js.eex
@@ -1,1 +1,4 @@
 $("#<%= @tr_id %>").fadeOut();
+$('.pagination').remove();
+$('.pagination_information').remove();
+$("<%= raw(@pagination) %>").insertBefore('.download_links')


### PR DESCRIPTION
**Issue:**
pagination block with page counter will not be updated after entity destroy

**How to reproduce:**
- create some entities
- follow to entities index
- note Displaing entities 1 - N of M under entity table
- remove entity

**Expected:**
- counters will decrease after destroying entity

**Actual:**
- counters stays the same as before

