### PR TITLE
Fix #283 : nil value for :map datatype

### DIFF
--- a/lib/ex_admin/table.ex
+++ b/lib/ex_admin/table.ex
@@ -30,7 +30,11 @@ defmodule ExAdmin.Table do
             for field_name <- Map.get(schema, :rows, []) do
               build_field(resource, conn, field_name, fn
                 _contents, {:map, f_name} ->
-                  for {k,v} <- Map.get(resource, f_name) do
+                  field_value = case Map.get(resource, f_name) do
+                    nil -> []
+                    value -> value
+                  end
+                  for {k,v} <- field_value do
                     tr do
                       value = ExAdmin.Render.to_string(v)
                       field_header "#{f_name} #{k}"


### PR DESCRIPTION
**Issue:**

When displaying a table with a :map field with nil value, a  500 HTTP code is returned.

The exception is
```(Protocol.UndefinedError) protocol Enumerable not implemented for nil```

**Expected:**

Returns a 200 HTTP code with a proper display.

**Fix:**

Fix was to set the field value to an empty list when nil to allow proper rendering.
