### PR TITLE
Allow overriding model_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,19 @@ config :ex_admin,
   ...
 ```
 
+### Overriding the model name
+
+You can override the name of a model by defining a `model_name/0` function on
+the module. This is useful if you want to use a different module for some of
+your actions.
+
+admin/my_model.ex
+```elixir
+def model_name do
+  "custom_name"
+end
+```
+
 ## Authentication
 
 ExAdmin leaves the job of authentication to 3rd party packages. For an example of using [Coherence](https://github.com/smpallen99/coherence) checkout the [Contact Demo Project](https://github.com/smpallen99/contact_demo).

--- a/lib/ex_admin/helpers.ex
+++ b/lib/ex_admin/helpers.ex
@@ -34,11 +34,13 @@ defmodule ExAdmin.Helpers do
     end
   end
 
+  def model_name(%{__struct__: name}), do: model_name(name)
   def model_name(resource) when is_atom(resource) do
-    resource |> ExAdmin.Utils.base_name |> Inflex.underscore()
-  end
-  def model_name(%{__struct__: name}) do
-    model_name name
+    if has_function?(resource, :model_name, 0) do
+      resource.model_name()
+    else
+      resource |> ExAdmin.Utils.base_name |> Inflex.underscore()
+    end
   end
 
   def build_link_for({:safe, _} = safe_contents, d, a, b, c) do

--- a/lib/ex_admin/utils.ex
+++ b/lib/ex_admin/utils.ex
@@ -193,7 +193,7 @@ defmodule ExAdmin.Utils do
     admin_resource_path(conn.assigns.resource.__struct__, method, args)
   end
   def admin_resource_path(resource_model, method, args) when is_atom(resource_model) do
-    resource_name = resource_model |> ExAdmin.Utils.base_name |> Inflex.underscore |> Inflex.pluralize
+    resource_name = resource_model |> ExAdmin.Helpers.model_name |> Inflex.pluralize
     apply(router(), :admin_resource_path, [endpoint(), method || :index, resource_name | args])
   end
   def admin_resource_path(resource, method, args) when is_map(resource) do

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -145,16 +145,16 @@ defmodule ExAdminTest.ControllerTest do
   test "restricted actions" do
     restricted = insert_restricted()
 
-    conn = get build_conn(), admin_resource_path(Restricted, :index)
+    conn = get build_conn(), admin_resource_path(TestExAdmin.Restricted, :index)
     assert html_response(conn, 200) =~ ~r/Simple/
 
-    conn = get build_conn(), admin_resource_path(Restricted, :new)
+    conn = get build_conn(), admin_resource_path(TestExAdmin.Restricted, :new)
     assert html_response(conn, 403) =~ ~r/Forbidden Request/
 
     conn = get build_conn(), admin_resource_path(restricted, :edit), %{}
     assert html_response(conn, 403) =~ ~r/Forbidden Request/
 
-    conn = post build_conn(), ExAdmin.Utils.admin_resource_path(Restricted, :create)
+    conn = post build_conn(), ExAdmin.Utils.admin_resource_path(TestExAdmin.Restricted, :create)
     assert html_response(conn, 403) =~ ~r/Forbidden Request/
 
     conn = delete build_conn(), admin_resource_path(restricted, :destroy)

--- a/test/helpers_test.exs
+++ b/test/helpers_test.exs
@@ -88,4 +88,20 @@ defmodule ExAdmin.HelpersTest do
   test "display_name first string field" do
     assert Helpers.display_name(%TestExAdmin.PhoneNumber{number: "5555"}) == "5555"
   end
+
+  test "model_name from atom" do
+    assert Helpers.model_name(TestExAdmin.PhoneNumber) == "phone_number"
+  end
+
+  test "model_name from struct" do
+    assert Helpers.model_name(%TestExAdmin.PhoneNumber{}) == "phone_number"
+  end
+
+  test "model_name from atom override" do
+    assert Helpers.model_name(TestExAdmin.ModelDisplayName) == "custom_name"
+  end
+
+  test "model_name from struct override" do
+    assert Helpers.model_name(%TestExAdmin.ModelDisplayName{}) == "custom_name"
+  end
 end

--- a/test/support/schema.exs
+++ b/test/support/schema.exs
@@ -275,6 +275,10 @@ defmodule TestExAdmin.ModelDisplayName do
   def display_name(resource) do
     resource.other
   end
+
+  def model_name do
+    "custom_name"
+  end
 end
 
 defmodule TestExAdmin.DefnDisplayName do


### PR DESCRIPTION
This allows using different schemas for saving and loading data. My specific use case is wanting a create form to have extra fields that get saved in associated records. For example, when I create an order in the database, I want to use the CreateOrder module, which also creates line items. For the most part you can do this by overriding the controller action, but when you have validation errors, you need to pass that changeset into the form builder, which then generates the form with the wrong path (/admin/create_orders rather than /admin/orders). I wasn't really sure where to document this, can you point me in the right direction?