### PR TITLE
added phoenix >= 1.3.0 config hint to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ config/config.exs
 ```elixir
 config :ex_admin,
   repo: MyProject.Repo,
-  module: MyProject,
+  module: MyProject,    # MyProject.Web for phoenix >= 1.3.0-rc 
   modules: [
     MyProject.ExAdmin.Dashboard,
   ]


### PR DESCRIPTION
 config must be adjusted with new namespacing, when used with phoenix >= 1.3.0