### PR TITLE
Refactored filter API

### DIFF
--- a/lib/ex_admin/filter.ex
+++ b/lib/ex_admin/filter.ex
@@ -68,6 +68,7 @@ defmodule ExAdmin.Filter do
   def filter_options(defn, field, key \\ nil)
   def filter_options(%{index_filters: filters}, field, key) when is_list(filters) and is_atom(key) do
     filters
+    |> List.flatten
     |> Enum.map(fn
       f when is_atom(f) -> {f, []}
       f when is_tuple(f) -> f

--- a/lib/ex_admin/register.ex
+++ b/lib/ex_admin/register.ex
@@ -980,13 +980,11 @@ defmodule ExAdmin.Register do
 
       filter false
 
-
   Only show index columns and filters for the specified fields:
 
       filter [:name, :email, :inserted_at]
-      filter [:name, :email, :inserted_at, labels: [email: "EMail Address"]]
-      filter only: [:name, :email, :inserted_at], label: [email: "EMail Address"]
-      filter except: [:encrypted_password], labels: [name: "Full Name"]
+      filter [:name, :inserted_at, email: [label: "EMail Address"]]
+      filter [:name, :inserted_at, posts: [order_by: [asc: :name]]]
 
   Note: Restricting fields with the `filter` macro also removes the field columns
   from the default index table.

--- a/lib/ex_admin/themes/active_admin/filter.ex
+++ b/lib/ex_admin/themes/active_admin/filter.ex
@@ -80,8 +80,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Filter do
     id = "q_#{owner_key}"
     name_label = field_label(name, defn)
     if assoc.__schema__(:type, :name) do
-      repo = Application.get_env :ex_admin, :repo
-      resources = repo.all assoc
+      resources = filter_resources(name, assoc, defn)
       selected_key = case q["#{owner_key}_eq"] do
         nil -> nil
         val -> val

--- a/lib/ex_admin/themes/admin_lte2/filter.ex
+++ b/lib/ex_admin/themes/admin_lte2/filter.ex
@@ -6,7 +6,6 @@ defmodule ExAdmin.Theme.AdminLte2.Filter do
   import ExAdmin.Utils
   import ExAdmin.Gettext
   import ExAdmin.Filter
-  import Ecto.Query, only: [from: 2]
   use Xain
 
   def theme_filter_view(conn, defn, q, order, scope) do
@@ -121,13 +120,7 @@ defmodule ExAdmin.Theme.AdminLte2.Filter do
   def build_field({name, %Ecto.Association.BelongsTo{related: assoc, owner_key: owner_key}}, q, defn) do
     id = "q_#{owner_key}"
     name_label = field_label(name, defn)
-    repo = Application.get_env :ex_admin, :repo
-    name_field = ExAdmin.Helpers.get_name_field(defn.resource_model)
-    resources = if is_nil(name_field) do
-      repo.all(assoc)
-    else
-      repo.all(from a in assoc, order_by: [asc: ^name_field])
-    end
+    resources = filter_resources(name, assoc, defn)
     selected_key = case q["#{owner_key}_eq"] do
       nil -> nil
       val -> val

--- a/test/filter_test.exs
+++ b/test/filter_test.exs
@@ -3,44 +3,46 @@ defmodule ExAdmin.FilterTest do
   alias ExAdmin.Filter
 
   ############
-  # filters
+  # filter fields
 
   test "filters" do
     defn = %TestExAdmin.ExAdmin.User{}
     assert Filter.fields(defn) == [name: :string, email: :string]
   end
-  test "filters except" do
-    defn = %TestExAdmin.ExAdmin.User{index_filters: [[except: [:name, :email]]]}
-    assert Filter.fields(defn) == [active: :boolean]
-  end
   test "filters all" do
     defn = %TestExAdmin.ExAdmin.User{index_filters: []}
     assert Filter.fields(defn) == [name: :string, email: :string, active: :boolean]
   end
-  test "filters only" do
-    defn = %TestExAdmin.ExAdmin.User{index_filters: [[only: [:name, :active]]]}
-    assert Filter.fields(defn) == [name: :string, active: :boolean]
-  end
-  test "filters only field_label" do
-    defn = %TestExAdmin.ExAdmin.User{index_filters: [[only: [:name, :email], labels: [email: "EMail Address"]]]}
-    assert Filter.fields(defn) == [name: :string, email: :string]
-  end
-  test "filters except field_label" do
-    defn = %TestExAdmin.ExAdmin.User{index_filters: [[except: [:active], labels: [email: "EMail Address"]]]}
-    assert Filter.fields(defn) == [name: :string, email: :string]
-  end
-  test "filters default field_label" do
-    defn = %TestExAdmin.ExAdmin.User{index_filters: [[labels: [email: "EMail Address"]]]}
-    assert Filter.fields(defn) == [name: :string, email: :string, active: :boolean]
-  end
-
-  test "filters except several fields" do
-    defn = %TestExAdmin.ExAdmin.Noprimary{index_filters: [[except: [:inserted_at, :updated_at]]]}
-    assert Filter.fields(defn) == [index: :integer, name: :string, description: :string]
+  test "filters field_label" do
+    defn = %TestExAdmin.ExAdmin.User{index_filters: [:name, :active, email: [label: "EMail Address"]]}
+    assert Filter.fields(defn) == [name: :string, active: :boolean, email: :string]
   end
 
   ############
-  # filters
+  # filter options
+  describe "filter_options" do
+    test "filter_options on empty" do
+      defn = %TestExAdmin.ExAdmin.User{index_filters: []}
+      assert Filter.filter_options(defn, :name) == nil
+      assert Filter.filter_options(defn, :name, :key) == nil
+    end
+
+    test "filter_options on atom" do
+      defn = %TestExAdmin.ExAdmin.User{index_filters: [:name]}
+      assert Filter.filter_options(defn, :name) == []
+      assert Filter.filter_options(defn, :name, :key) == nil
+    end
+
+    test "filter_options on options" do
+      defn = %TestExAdmin.ExAdmin.User{index_filters: [:name, email: [label: "EMail Address"]]}
+      assert Filter.filter_options(defn, :email) == [label: "EMail Address"]
+      assert Filter.filter_options(defn, :email, :label) == "EMail Address"
+      assert Filter.filter_options(defn, :email, :key) == nil
+    end
+  end
+
+  ############
+  # filter labels
 
   test "filter_label default" do
     defn = %TestExAdmin.ExAdmin.User{index_filters: []}
@@ -48,7 +50,7 @@ defmodule ExAdmin.FilterTest do
     assert Filter.field_label(:email, defn) == "Email"
   end
   test "filter_label label" do
-    defn = %TestExAdmin.ExAdmin.User{index_filters: [[labels: [email: "EMail Address", name: "Full Name"]]]}
+    defn = %TestExAdmin.ExAdmin.User{index_filters: [name: [label: "Full Name"], email: [label: "EMail Address"]]}
     assert Filter.field_label(:name, defn) == "Full Name"
     assert Filter.field_label(:email, defn) == "EMail Address"
   end

--- a/test/index_test.exs
+++ b/test/index_test.exs
@@ -55,22 +55,8 @@ defmodule ExAdminTest.IndexTest do
     assert floki_text(html, "td.td-name", "Test")
     assert floki_text(html, "td.td-description", "Something")
   end
-  test "default_index_view with filter only", %{resource: resource, defn: defn, page: page} do
-    defn = struct(defn, index_filters: [[only: [:name, :description]]])
-    conn = setup_conn defn, resource
-    {:safe, html} = Index.default_index_view conn, page, []
-    assert floki_text(html, "td.td-name", "Test")
-    assert floki_text(html, "td.td-description", "Something")
-  end
-  test "default_index_view with filter except", %{resource: resource, defn: defn, page: page} do
-    defn = struct(defn, index_filters: [[except: [:description]]])
-    conn = setup_conn defn, resource
-    {:safe, html} = Index.default_index_view conn, page, []
-    assert floki_text(html, "td.td-name", "Test")
-    assert Floki.find(html, "td.td-description") == []
-  end
   test "default_index_view with filter labels", %{resource: resource, defn: defn, page: page} do
-    defn = struct(defn, index_filters: [[labels: [name: "name"]]])
+    defn = struct(defn, index_filters: [[:description, name: [label: "name"]]])
     conn = setup_conn defn, resource
     {:safe, html} = Index.default_index_view conn, page, []
     assert floki_text(html, "td.td-name", "Test")

--- a/test/support/admin_resources.exs
+++ b/test/support/admin_resources.exs
@@ -33,7 +33,7 @@ defmodule TestExAdmin.ExAdmin.User do
   use ExAdmin.Register
 
   register_resource TestExAdmin.User do
-    filter only: [:name, :email]
+    filter [:name, :email]
     show user do
       panel "No IDs" do
         markup_contents do

--- a/test/themes/filter_test.exs
+++ b/test/themes/filter_test.exs
@@ -29,7 +29,7 @@ defmodule ExAdmin.ThemeFilterTest do
     assert Floki.find(html, "label.label") |> Floki.text == "Search Name"
   end
   test "AdminLte2 build_field string with label option" do
-    defn = %TestExAdmin.ExAdmin.User{index_filters: [[labels: [email: "EMail Address"]]]}
+    defn = %TestExAdmin.ExAdmin.User{index_filters: [email: [label: "EMail Address"]]}
     html = AdminLte2.Filter.build_field({:email, :string}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "Search EMail Address"
   end
@@ -39,7 +39,7 @@ defmodule ExAdmin.ThemeFilterTest do
     assert Floki.find(html, "label.label") |> Floki.text == "Inserted At"
   end
   test "AdminLte2 build_field datetime with label option" do
-    defn = %TestExAdmin.ExAdmin.Simple{index_filters: [[labels: [inserted_at: "Created On"]]]}
+    defn = %TestExAdmin.ExAdmin.Simple{index_filters: [inserted_at: [label: "Created On"]]}
     html = AdminLte2.Filter.build_field({:inserted_at, Ecto.DateTime}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "Created On"
   end
@@ -49,7 +49,7 @@ defmodule ExAdmin.ThemeFilterTest do
     assert Floki.find(html, "label.label") |> Floki.text == "Index"
   end
   test "AdminLte2 build_field integer with label option" do
-    defn = %TestExAdmin.ExAdmin.Noprimary{index_filters: [[labels: [index: "Index Number"]]]}
+    defn = %TestExAdmin.ExAdmin.Noprimary{index_filters: [index: [label: "Index Number"]]}
     html = AdminLte2.Filter.build_field({:index, :integer}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "Index Number"
   end
@@ -65,7 +65,7 @@ defmodule ExAdmin.ThemeFilterTest do
   test "AdminLte2 build_field belongs_to with label option" do
     # save = Application.get_env :ex_admin, :repo
     # Application.put_env :ex_admin, :repo, __MODULE__
-    defn = %TestExAdmin.ExAdmin.Product{index_filters: [[labels: [user: "Account"]]]}
+    defn = %TestExAdmin.ExAdmin.Product{index_filters: [user: [label: "Account"]]}
     assoc = defn.resource_model.__schema__(:association, :user)
     html = AdminLte2.Filter.build_field({:user, assoc}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "Account"
@@ -77,7 +77,7 @@ defmodule ExAdmin.ThemeFilterTest do
     assert Floki.find(html, "label.label") |> Floki.text == "Active"
   end
   test "AdminLte2 build_field boolean with label option" do
-    defn = %TestExAdmin.ExAdmin.User{index_filters: [[labels: [active: "active?"]]]}
+    defn = %TestExAdmin.ExAdmin.User{index_filters: [active: [label: "active?"]]}
     html = AdminLte2.Filter.build_field({:active, :boolean}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "active?"
   end
@@ -87,7 +87,7 @@ defmodule ExAdmin.ThemeFilterTest do
     assert Floki.find(html, "label.label") |> Floki.text == "Key"
   end
   test "AdminLte2 build_field UUID with label option" do
-    defn = %TestExAdmin.ExAdmin.UUIDSchema{index_filters: [[labels: [key: "id"]]]}
+    defn = %TestExAdmin.ExAdmin.UUIDSchema{index_filters: [key: [label: "id"]]}
     html = AdminLte2.Filter.build_field({:key, Ecto.UUID}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "id"
   end
@@ -101,7 +101,7 @@ defmodule ExAdmin.ThemeFilterTest do
     assert Floki.find(html, "label.label") |> Floki.text == "Name"
   end
   test "ActiveAdmin build_field string with label option" do
-    defn = %TestExAdmin.ExAdmin.User{index_filters: [[labels: [email: "EMail Address"]]]}
+    defn = %TestExAdmin.ExAdmin.User{index_filters: [email: [label: "EMail Address"]]}
     html = ActiveAdmin.Filter.build_field({:email, :string}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "EMail Address"
   end
@@ -111,7 +111,7 @@ defmodule ExAdmin.ThemeFilterTest do
     assert Floki.find(html, "label.label") |> Floki.text == "Inserted At"
   end
   test "ActiveAdmin build_field datetime with label option" do
-    defn = %TestExAdmin.ExAdmin.Simple{index_filters: [[labels: [inserted_at: "Created On"]]]}
+    defn = %TestExAdmin.ExAdmin.Simple{index_filters: [inserted_at: [label: "Created On"]]}
     html = ActiveAdmin.Filter.build_field({:inserted_at, Ecto.DateTime}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "Created On"
   end
@@ -121,7 +121,7 @@ defmodule ExAdmin.ThemeFilterTest do
     assert Floki.find(html, "label.label") |> Floki.text == "Index"
   end
   test "ActiveAdmin build_field integer with label option" do
-    defn = %TestExAdmin.ExAdmin.Noprimary{index_filters: [[labels: [index: "Index Number"]]]}
+    defn = %TestExAdmin.ExAdmin.Noprimary{index_filters: [index: [label: "Index Number"]]}
     html = ActiveAdmin.Filter.build_field({:index, :integer}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "Index Number"
   end
@@ -132,7 +132,7 @@ defmodule ExAdmin.ThemeFilterTest do
     assert Floki.find(html, "label.label") |> Floki.text == "User"
   end
   test "ActiveAdmin build_field belongs_to with label option" do
-    defn = %TestExAdmin.ExAdmin.Product{index_filters: [[labels: [user: "Account"]]]}
+    defn = %TestExAdmin.ExAdmin.Product{index_filters: [user: [label: "Account"]]}
     assoc = defn.resource_model.__schema__(:association, :user)
     html = ActiveAdmin.Filter.build_field({:user, assoc}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "Account"
@@ -143,7 +143,7 @@ defmodule ExAdmin.ThemeFilterTest do
     assert Floki.find(html, "label.label") |> Floki.text == "Active"
   end
   test "ActiveAdmin build_field boolean with label option" do
-    defn = %TestExAdmin.ExAdmin.User{index_filters: [[labels: [active: "active?"]]]}
+    defn = %TestExAdmin.ExAdmin.User{index_filters: [active: [label: "active?"]]}
     html = ActiveAdmin.Filter.build_field({:active, :boolean}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "active?"
   end
@@ -153,7 +153,7 @@ defmodule ExAdmin.ThemeFilterTest do
     assert Floki.find(html, "label.label") |> Floki.text == "Key"
   end
   test "ActiveAdmin build_field UUID with label option" do
-    defn = %TestExAdmin.ExAdmin.UUIDSchema{index_filters: [[labels: [key: "id"]]]}
+    defn = %TestExAdmin.ExAdmin.UUIDSchema{index_filters: [key: [label: "id"]]}
     html = ActiveAdmin.Filter.build_field({:key, Ecto.UUID}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "id"
   end


### PR DESCRIPTION
OK, finally refactored the API, and updated all tests to pass. New API for labels:

`filter [:name, email: [label: "EMail Address"]]`

API example for ordering a `belongs_to` association:

`filter [post: [order_by: [asc: :name]]]`

I spent a lot of time thinking about this, and I ended up removing `:only` and `:except` as options. A few reasons:

1. `:only` is basically useless. If you have an explicit list of filters, wrapping it in an `:only` keyword doesn't do anything but add extra code. Since this refactor breaks backwards compatibility, I figured we might as well kill it off.

2. `:except` - this one is a little trickier to justify, but in the end I'd rather take a principled approach of having to explicitly specify which filters you want to enable for a particular screen. If we leave this here and let users specify `:except`, they'll end up adding filters to various admin screens by simply adding new fields to their models.