### PR TITLE
Update brunch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.min.css -diff
+*.min.js -diff
+*.css.map -diff
+*.js.map -diff

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "repository": {
   },
   "dependencies": {
-    "brunch": "^1.8.1",
-    "babel-brunch": "^5.1.1",
-    "clean-css-brunch": ">= 1.0 < 1.8",
-    "css-brunch": ">= 1.0 < 1.8",
-    "javascript-brunch": ">= 1.0 < 1.8",
-    "sass-brunch": "^1.8.10",
-    "uglify-js-brunch": ">= 1.0 < 1.8"
+    "babel-brunch": "~6.1.1",
+    "brunch": "~2.10.9",
+    "clean-css-brunch": "~2.10.0",
+    "css-brunch": "~2.10.0",
+    "javascript-brunch": "~2.10.0",
+    "sass-brunch": "~2.10.4",
+    "uglify-js-brunch": "~2.10.0"
   }
 }


### PR DESCRIPTION
The version of Brunch specified in `package.json` is too old to function (its build of `fsevents` causes v8 to crash.) This forces you to install an external Brunch (`npm install -g brunch`) if you want to do any development on ExAdmin itself.

This PR updates Brunch and its plugins to more recent versions, and then uses the newer Brunch build to re-generate the prebuilt assets in `priv/static`.