### PR TITLE
Permit ID columns in sortable tables to use the Ecto :binary_id (i.e. UUID) type

### DIFF
--- a/web/controllers/admin_association_controller.ex
+++ b/web/controllers/admin_association_controller.ex
@@ -48,7 +48,11 @@ defmodule ExAdmin.AdminAssociationController do
 
     selected_ids
     |> Enum.each(fn(assoc_id) ->
-      assoc_id = String.to_integer(assoc_id)
+      assoc_id = if String.match?(assoc_id, ~r/^\d+$/) do
+        String.to_integer(assoc_id)
+      else
+        assoc_id
+      end
       Ecto.build_assoc(resource, through_assoc, %{resource_key => resource_id, assoc_key => assoc_id})
       |> repo().insert!
     end)

--- a/web/static/js/active_admin/lib/sortable_associations.js
+++ b/web/static/js/active_admin/lib/sortable_associations.js
@@ -18,7 +18,7 @@ $(document).ready(function() {
           //$("#progress").show();
           var positions = [];
           $.each($('table.sortable tbody tr'), function(position, obj){
-            var reg = /(\w+_?)+_(\d+)/;
+            var reg = /^(\w+_?)_([-0-9a-f]+)$/i;
             var parts = reg.exec($(obj).prop('id'));
             if (parts) {
               positions = positions.concat({'id': parts[2], 'position': position});


### PR DESCRIPTION
The current code in `sortable_associations.js` assumes `id` columns have `\d+` contents. This breaks when using Ecto schemas with `:binary_id`-typed ID columns.

This PR expands the match pattern to (loosely) match hexadecimal-encoded UUIDs as well as natural numbers, using `[-0-9a-f]+`. It also tightens the match pattern with beginning/end guards.

Depends on #344.