### PR TITLE
Require Hound only in Test Env

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule ExAdmin.Mixfile do
       {:ex_queb, "~> 1.0"},
       {:excoveralls, "~> 0.5", only: :test},
       {:gettext, "~> 0.11"},
-      {:hound, "~> 1.0"}
+      {:hound, "~> 1.0", only: :test}
     ]
   end
 


### PR DESCRIPTION
Hound is only required for Integration Tests. It should not be required for Prod.