### PR TITLE
Default Collection for Checkboxes

### DIFF
--- a/lib/ex_admin/form.ex
+++ b/lib/ex_admin/form.ex
@@ -887,12 +887,32 @@ defmodule ExAdmin.Form do
     end
   end
 
+
+  @doc """
+  Setups the default collection on a inputs dsl request and then calls
+  build_item again with the collection added
+  """
+  def build_item(conn, %{type: :inputs, name: name, opts: %{as: type}} = options,
+      resource, model_name, errors) when is_atom(name) do
+    # Get the model from the atom name
+    mod = name
+          |> Atom.to_string
+          |> String.capitalize
+          |> Inflex.singularize
+          |> String.to_atom
+    module = Application.get_env(:ex_admin, :module)
+              |> Module.concat(mod)
+    opts = put_in(options,[:opts, :collection], apply(module, :all, []))
+
+    # call the build item with the default collection
+    build_item(conn, opts, resource, model_name, errors)
+  end
+
   @doc """
   Handle building the items for an input block.
 
   This is where each of the fields will be build
   """
-
   def build_item(conn, %{type: :inputs, name: _field_name} = item, resource, model_name, errors) do
     opts = Map.get(item, :opts, [])
     Adminlog.debug "build_item 10: #{inspect _field_name}"

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -1,6 +1,6 @@
 defmodule ExAdmin.FormTest do
   use ExUnit.Case, async: true
-  alias TestExAdmin.{Simple, User, Role, Repo}
+  alias TestExAdmin.{Simple, User, Role, Repo, Noid}
   use Xain
 
   setup do
@@ -71,6 +71,17 @@ defmodule ExAdmin.FormTest do
       Repo.insert! Role.changeset(%Role{}, %{name: name})
     end
     item = %{type: :inputs, name: :roles, opts: %{as: :check_boxes, collection: roles}}
+    res = ExAdmin.Form.build_item(conn, item, %User{}, "user", nil)
+    assert Floki.find(res, "div label") |> hd |> Floki.text == "Roles"
+    role_boxes = Floki.find(res, "div div.col-sm-10 input[type=checkbox]")
+    assert Enum.count(role_boxes) == 2
+  end
+
+  test "build_item :inputs as: :check_boxes collection default collection", %{conn: conn} do
+    roles = for name <- ~w(user admin) do
+      Repo.insert! Role.changeset(%Role{}, %{name: name})
+    end
+    item = %{type: :inputs, name: :roles, opts: %{as: :check_boxes}}
     res = ExAdmin.Form.build_item(conn, item, %User{}, "user", nil)
     assert Floki.find(res, "div label") |> hd |> Floki.text == "Roles"
     role_boxes = Floki.find(res, "div div.col-sm-10 input[type=checkbox]")


### PR DESCRIPTION
Motivation:
  - This pr add some intelligence to the form build dsl and assumes that
    when a collection is not passed the form should call all on the
    supplied model name.
    enhancement #95