### PR TITLE
Fixes #351: enable batch actions with UUIDs

### DIFF
--- a/web/controllers/admin_resource_controller.ex
+++ b/web/controllers/admin_resource_controller.ex
@@ -177,6 +177,7 @@ defmodule ExAdmin.AdminResourceController do
 
   defp to_integer(:id, string), do: string
   defp to_integer(:string, string), do: string
+  defp to_integer(:binary_id, string), do: string
   defp to_integer(:integer, string) do
     case Integer.parse string do
       {int, ""} -> int


### PR DESCRIPTION
Make batch operations for UUIDs (binary_id) work.