### PR TITLE
Support Elixir.DateTime, NaiveDateTime and Elixir.Date and Time types

### DIFF
--- a/lib/ex_admin/form.ex
+++ b/lib/ex_admin/form.ex
@@ -1011,11 +1011,27 @@ defmodule ExAdmin.Form do
     %{name: model_name, model: resource, id: model_name, class: "form-control"}
     |> datetime_select(field_name, Map.get(opts, :options, []))
   end
+  def build_control(DateTime, resource, opts, model_name, field_name, _ext_name) do
+    %{name: model_name, model: resource, id: model_name, class: "form-control"}
+    |> datetime_select(field_name, Map.get(opts, :options, []))
+  end
+  def build_control(NaiveDateTime, resource, opts, model_name, field_name, _ext_name) do
+    %{name: model_name, model: resource, id: model_name, class: "form-control"}
+    |> datetime_select(field_name, Map.get(opts, :options, []))
+  end
   def build_control(Ecto.Date, resource, opts, model_name, field_name, _ext_name) do
     %{name: model_name, model: resource, id: model_name, class: "form-control"}
     |> date_select(field_name, Map.get(opts, :options, []))
   end
   def build_control(Ecto.Time, resource, opts, model_name, field_name, _ext_name) do
+    %{name: model_name, model: resource, id: model_name, class: "form-control"}
+    |> time_select(field_name, Map.get(opts, :options, []))
+  end
+  def build_control(Date, resource, opts, model_name, field_name, _ext_name) do
+    %{name: model_name, model: resource, id: model_name, class: "form-control"}
+    |> date_select(field_name, Map.get(opts, :options, []))
+  end
+  def build_control(Time, resource, opts, model_name, field_name, _ext_name) do
     %{name: model_name, model: resource, id: model_name, class: "form-control"}
     |> time_select(field_name, Map.get(opts, :options, []))
   end
@@ -1221,6 +1237,8 @@ defmodule ExAdmin.Form do
     do: %{hour: hour, min: min, sec: Map.get(map, "sec", 0), usec: Map.get(map, "usec", 0)}
   defp time_value(%{hour: hour, min: min} = map),
     do: %{hour: hour, min: min, sec: Map.get(map, :sec, 0), usec: Map.get(map, :usec, 0)}
+  defp time_value(%{hour: hour, minute: min} = map),
+    do: %{hour: hour, min: min, sec: Map.get(map, :second, 0), usec: elem(Map.get(map, :microsecond, {0,0}),0)}
 
   defp time_value({_, {hour, min, sec, usec}}),
     do: %{hour: hour, min: min, sec: sec, usec: usec}
@@ -1230,7 +1248,6 @@ defmodule ExAdmin.Form do
     do: %{hour: hour, min: min, sec: sec, usec: nil}
   defp time_value({hour, min, sec}),
     do: %{hour: hour, min: min, sec: sec, usec: nil}
-
   defp time_value(nil),
     do: %{hour: nil, min: nil, sec: nil, usec: nil}
   defp time_value(other),

--- a/lib/ex_admin/table.ex
+++ b/lib/ex_admin/table.ex
@@ -196,12 +196,32 @@ defmodule ExAdmin.Table do
       text to_string(dt)
     end
   end
+  def handle_contents(%DateTime{} = dt, field_name) do
+    td class: to_class("td-", field_name) do
+      text to_string(dt)
+    end
+  end
+  def handle_contents(%NaiveDateTime{} = dt, field_name) do
+    td class: to_class("td-", field_name) do
+      text to_string(dt)
+    end
+  end
   def handle_contents(%Ecto.Time{} = dt, field_name) do
     td class: to_class("td-", field_name) do
       text to_string(dt)
     end
   end
   def handle_contents(%Ecto.Date{} = dt, field_name) do
+    td class: to_class("td-", field_name) do
+      text to_string(dt)
+    end
+  end
+  def handle_contents(%Time{} = dt, field_name) do
+    td class: to_class("td-", field_name) do
+      text to_string(dt)
+    end
+  end
+  def handle_contents(%Date{} = dt, field_name) do
     td class: to_class("td-", field_name) do
       text to_string(dt)
     end

--- a/lib/ex_admin/themes/active_admin/filter.ex
+++ b/lib/ex_admin/themes/active_admin/filter.ex
@@ -47,7 +47,7 @@ defmodule ExAdmin.Theme.ActiveAdmin.Filter do
     end
   end
 
-  def build_field({name, type}, q, defn) when type in [Ecto.DateTime, Ecto.Date, Ecto.Time, Timex.Ecto.DateTime, Timex.Ecto.Date, Timex.Ecto.Time, Timex.Ecto.DateTimeWithTimezone, NaiveDateTime, :naive_datetime] do
+  def build_field({name, type}, q, defn) when type in [Ecto.DateTime, Ecto.Date, Ecto.Time, Timex.Ecto.DateTime, Timex.Ecto.Date, Timex.Ecto.Time, Timex.Ecto.DateTimeWithTimezone, NaiveDateTime, :naive_datetime, DateTime, :utx_datetime] do
     name_label = field_label(name, defn)
     gte_value = get_value("#{name}_gte", q)
     lte_value = get_value("#{name}_lte", q)

--- a/lib/ex_admin/themes/admin_lte2/filter.ex
+++ b/lib/ex_admin/themes/admin_lte2/filter.ex
@@ -61,7 +61,7 @@ defmodule ExAdmin.Theme.AdminLte2.Filter do
       end
   end
 
-  def build_field({name, type}, q, defn) when type in [Ecto.DateTime, Ecto.Date, Ecto.Time, Timex.Ecto.DateTime, Timex.Ecto.Date, Timex.Ecto.Time, Timex.Ecto.DateTimeWithTimezone, NaiveDateTime, :naive_datetime] do
+  def build_field({name, type}, q, defn) when type in [Ecto.DateTime, Ecto.Date, Ecto.Time, Timex.Ecto.DateTime, Timex.Ecto.Date, Timex.Ecto.Time, Timex.Ecto.DateTimeWithTimezone, NaiveDateTime, :naive_datetime, DateTime, :utc_datetime] do
     gte_value = get_value("#{name}_gte", q)
     lte_value = get_value("#{name}_lte", q)
     name_label = field_label(name, defn)

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -31,6 +31,19 @@ defmodule ExAdmin.FormTest do
     refute options == []
   end
 
+  test "build_control NativeDateTime" do
+    res = ExAdmin.Form.build_control(DateTime, %Simple{inserted_at: DateTime.utc_now}, %{}, "simple", :inserted_at, "simple_inserted_at")
+    select = Floki.find(res, "select[name='simple[inserted_at][year]']")
+    refute select == []
+    options = Floki.find(res, "select[name='simple[inserted_at][year]'] option")
+    refute options == []
+
+    select = Floki.find(res, "select[name='simple[inserted_at][hour]']")
+    refute select == []
+    options = Floki.find(res, "select[name='simple[inserted_at][hour]'] option")
+    refute options == []
+  end
+
   test "build_control Date" do
     res = ExAdmin.Form.build_control(Ecto.Date, %Simple{inserted_at: Ecto.DateTime.utc}, %{}, "simple", :inserted_at, "simple_inserted_at")
     select = Floki.find(res, "select[name='simple[inserted_at][year]']")

--- a/test/themes/filter_test.exs
+++ b/test/themes/filter_test.exs
@@ -38,6 +38,11 @@ defmodule ExAdmin.ThemeFilterTest do
     html = AdminLte2.Filter.build_field({:inserted_at, Ecto.DateTime}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "Inserted At"
   end
+  test "AdminLte2 build_field native datetime" do
+    defn = %TestExAdmin.ExAdmin.Simple{index_filters: []}
+    html = AdminLte2.Filter.build_field({:inserted_at, DateTime}, nil, defn)
+    assert Floki.find(html, "label.label") |> Floki.text == "Inserted At"
+  end
   test "AdminLte2 build_field datetime with label option" do
     defn = %TestExAdmin.ExAdmin.Simple{index_filters: [inserted_at: [label: "Created On"]]}
     html = AdminLte2.Filter.build_field({:inserted_at, Ecto.DateTime}, nil, defn)
@@ -108,6 +113,11 @@ defmodule ExAdmin.ThemeFilterTest do
   test "ActiveAdmin build_field datetime" do
     defn = %TestExAdmin.ExAdmin.Simple{index_filters: []}
     html = ActiveAdmin.Filter.build_field({:inserted_at, Ecto.DateTime}, nil, defn)
+    assert Floki.find(html, "label.label") |> Floki.text == "Inserted At"
+  end
+  test "ActiveAdmin build_field native datetime" do
+    defn = %TestExAdmin.ExAdmin.Simple{index_filters: []}
+    html = ActiveAdmin.Filter.build_field({:inserted_at, DateTime}, nil, defn)
     assert Floki.find(html, "label.label") |> Floki.text == "Inserted At"
   end
   test "ActiveAdmin build_field datetime with label option" do

--- a/web/ex_admin/errors_helper.ex
+++ b/web/ex_admin/errors_helper.ex
@@ -33,6 +33,8 @@ defmodule ExAdmin.ErrorsHelper do
 
   defp flatten_errors(errors_array, assoc_prefixes, prefix \\ nil)
   defp flatten_errors(%Ecto.Changeset{changes: changes, errors: errors}, assoc_prefixes, prefix) when errors == [] or is_nil(prefix) do
+    changes = Enum.reject(changes, fn({_,v}) -> is_struct(v) end)
+    |> Enum.into(%{})
     errors ++ flatten_errors(changes, assoc_prefixes, prefix)
   end
 
@@ -80,4 +82,7 @@ defmodule ExAdmin.ErrorsHelper do
       end
     end)
   end
+
+  defp is_struct(%{__struct__: _}), do: true
+  defp is_struct(_), do: false
 end


### PR DESCRIPTION
Other than adding to build_control in form.ex , in the Elixir DateTime types there is the `:minute` keyword instead of `:min` like in the Ecto.DateTime types. So I added a function to the time_value functions.

No sure though, if there are more parts that need to change.