### PR TITLE
Add support for prompt in date type.

### DIFF
--- a/lib/ex_admin/form.ex
+++ b/lib/ex_admin/form.ex
@@ -1290,7 +1290,7 @@ defmodule ExAdmin.Form do
     end
   end
 
-  defp build_select(_name, _type, value, opts) do
+  defp build_select(_name, type, value, opts) do
     value = if Range.range? value do
       Enum.map value, fn(x) ->
         val = Integer.to_string x
@@ -1300,6 +1300,7 @@ defmodule ExAdmin.Form do
       value
     end
     select "", [{:class, "form-control date-time"} |opts] do
+      if opts[:prompt], do: handle_prompt(type, [opts: %{prompt: opts[:prompt]}])
       current_value = "#{opts[:value]}"
       Enum.map value, fn({k,v}) ->
         selected = if v == current_value, do: [selected: "selected"], else: []

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -39,6 +39,19 @@ defmodule ExAdmin.FormTest do
     refute options == []
   end
 
+  test "build_control Date with prompts" do
+    res = ExAdmin.Form.build_control(Ecto.Date, %Simple{inserted_at: Ecto.DateTime.utc}, %{options: [year: [prompt: "year"], month: [prompt: "month"], day: [prompt: "day"]]}, "simple", :inserted_at, "simple_inserted_at")
+    year_prompt = res
+    |> Floki.find("select[name='simple[inserted_at][year]'] option[value='']")
+    assert year_prompt == [{"option", [{"value", ""}], ["year"]}]
+    month_prompt = res
+    |> Floki.find("select[name='simple[inserted_at][month]'] option[value='']")
+    assert month_prompt == [{"option", [{"value", ""}], ["month"]}]
+    day_prompt = res
+    |> Floki.find("select[name='simple[inserted_at][day]'] option[value='']")
+    assert day_prompt == [{"option", [{"value", ""}], ["day"]}]
+  end
+
   test "build_control Time" do
     res = ExAdmin.Form.build_control(Ecto.Time, %Simple{inserted_at: Ecto.DateTime.utc}, %{}, "simple", :inserted_at, "simple_inserted_at")
     select = Floki.find(res, "select[name='simple[inserted_at][hour]']")


### PR DESCRIPTION
Add support for `:prompt` options in form inputs.
This will allow to have an extra option in the select with an empty value and the label specified after `prompt:`
Usage:
```elixir
input user, :inserted_at, options: [year: [prompt: "Year"], month: [prompt: "Month"], day: [prompt: "Day"]]
```
