### PR TITLE
Fix exception on ExAdmin.ErrorsHelper.flatten_errors/3

### DIFF
--- a/test/controller/errors_helper_test.exs
+++ b/test/controller/errors_helper_test.exs
@@ -7,6 +7,7 @@ defmodule TestExAdmin.ErrorsHelperTests do
 
     schema "contacts" do
       field :first_name, :string, null: false
+      field :birthday, :date
       many_to_many :phone_numbers, TestExAdmin.PhoneNumber, join_through: TestExAdmin.ContactPhoneNumber
       timestamps()
     end
@@ -15,7 +16,7 @@ defmodule TestExAdmin.ErrorsHelperTests do
 
     def changeset(model, params \\ %{}) do
       model
-      |> cast(params, @fields)
+      |> cast(params, [:birthday | @fields])
       |> validate_required(@fields)
       |> cast_assoc(:phone_numbers, required: false)
     end
@@ -70,6 +71,15 @@ defmodule TestExAdmin.ErrorsHelperTests do
 
   test "simple errors" do
     params = %{}
+    changeset = TestExAdmin.Contact.changeset(%TestExAdmin.Contact{}, params)
+
+    errors = ExAdmin.ErrorsHelper.create_errors(changeset, TestExAdmin.Contact)
+    assert changeset.valid? == false
+    assert errors == [first_name: {"can't be blank", [validation: :required]}]
+  end
+
+  test "simple errors when schema has field with struct type" do
+    params = %{birthday: %{day: 8, month: 6, year: 2017}}
     changeset = TestExAdmin.Contact.changeset(%TestExAdmin.Contact{}, params)
 
     errors = ExAdmin.ErrorsHelper.create_errors(changeset, TestExAdmin.Contact)

--- a/web/ex_admin/errors_helper.ex
+++ b/web/ex_admin/errors_helper.ex
@@ -49,6 +49,8 @@ defmodule ExAdmin.ErrorsHelper do
     end)
   end
 
+  defp flatten_errors(%{__struct__: _struct}, _, _), do: nil
+
   defp flatten_errors(%{} = errors_map, assoc_prefixes, prefix) do
     Enum.map(errors_map, fn({k, x}) ->
       with k <- if(not is_atom(k), do: String.to_atom(k), else: k),


### PR DESCRIPTION
Before when the schema contained a field which was translated to an
Elixir struct the flatten_errors function would treat it as a Map and
try to map over its elements, and that would raise `Protocol.UndefinedError`.

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for #Ecto.Date<2017-06-08>
     stacktrace:
       (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
       (elixir) lib/enum.ex:116: Enumerable.reduce/3
       (elixir) lib/enum.ex:1767: Enum.map/2
       (elixir) lib/enum.ex:1233: anonymous fn/3 in Enum.map/2
       (stdlib) lists.erl:1263: :lists.foldl/3
       (elixir) lib/enum.ex:1772: Enum.map/2
       (ex_admin) web/ex_admin/errors_helper.ex:36: ExAdmin.ErrorsHelper.flatten_errors/3
       (ex_admin) web/ex_admin/errors_helper.ex:29: ExAdmin.ErrorsHelper.create_errors/2
```