### PR TITLE
Updating web path

### DIFF
--- a/lib/mix/utils.ex
+++ b/lib/mix/utils.ex
@@ -15,7 +15,7 @@ defmodule Mix.ExAdmin.Utils do
   end
 
   def web_path() do
-    path1 = Path.join ["lib", to_string(Mix.Phoenix.otp_app()), "web"]
+    path1 = Path.join ["lib", to_string(Mix.Phoenix.otp_app()) <> "_web"]
     path2 = "web"
     cond do
       File.exists? path1 -> path1


### PR DESCRIPTION
Updating web path for newly generated Phoenix 1.3 projects.

Change needed because new Phoenix 1.3 projects create the web path at`lib/<project_name>_web` instead of `lib/<project_name_/web`

If you don't have this change, you get an error like this:

```
mix admin.install
* creating css files
* creating js files
* updating config/config.exs
* skipping xain config. It already exists.
** (RuntimeError) Could not find web path 'lib/<project name>/web'.
    lib/mix/utils.ex:24: Mix.ExAdmin.Utils.web_path/0
    lib/mix/tasks/admin.install.ex:230: Mix.Tasks.Admin.Install.do_dashboard/1
    lib/mix/tasks/admin.install.ex:55: Mix.Tasks.Admin.Install.do_install/1
    (mix) lib/mix/task.ex:294: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
```

See https://github.com/smpallen99/ex_admin/issues/399#issuecomment-329228347 for reference.
