### PR TITLE
Remove duplicate phoenix_html dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,6 @@ defmodule ExAdmin.Mixfile do
       {:postgrex, "~> 0.13", only: :test},
       {:floki, "~> 0.8", only: :test},
       {:cowboy, "~> 1.0"},
-      {:phoenix_html, "~> 2.5"},
       {:inflex, "~> 1.7"},
       {:scrivener_ecto, "~> 1.1"},
       {:xain, "~> 0.6"},


### PR DESCRIPTION
cherry pick from master

on elixir 1.5
the following warnings occurred
```
==> ex_admin
warning: the dependency :phoenix_html is duplicated at the top level, please remove one of them
warning: the dependency :phoenix_html is duplicated at the top level, please remove one of them
```