### PR TITLE
[WIP] Fix file path used in phoenix 1.3 projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ config/config.exs
 ```elixir
 config :ex_admin,
   repo: MyProject.Repo,
-  module: MyProject,    # MyProject.Web for phoenix >= 1.3.0-rc
+  module: MyProject,    # MyProjectWeb for phoenix >= 1.3.0-rc
   modules: [
-    MyProject.ExAdmin.Dashboard,
+    MyProject.ExAdmin.Dashboard, # MyProjectWeb for phoenix >= 1.3.0-rc
   ]
 
 ```
@@ -89,8 +89,8 @@ Add the admin routes
 
 web/router.ex
 ```elixir
-defmodule MyProject.Router do
-  use MyProject.Web, :router
+defmodule MyProject.Router do # MyProjectWeb for phoenix >= 1.3.0-rc
+  use MyProjectWeb, :router
   use ExAdmin.Router
   ...
   scope "/", MyProject do

--- a/lib/mix/utils.ex
+++ b/lib/mix/utils.ex
@@ -15,7 +15,7 @@ defmodule Mix.ExAdmin.Utils do
   end
 
   def web_path() do
-    path1 = Path.join ["lib", to_string(Mix.Phoenix.otp_app()) <> "_web"]
+    path1 = Path.join ["lib", to_string(Mix.Phoenix.otp_app())]
     path2 = "web"
     cond do
       File.exists? path1 -> path1
@@ -42,4 +42,3 @@ defmodule Mix.ExAdmin.Utils do
   @doc "Print an error message in red"
   def error(message), do: IO.puts "==> #{IO.ANSI.red}#{message}#{IO.ANSI.reset}"
 end
-


### PR DESCRIPTION
There were some gaps in the instructions for installing with phoenix 1.3. Additionally, there was an extra `_web` added on to the directory path, which meant it was looking for `app_web_web`. #424 