### PR TITLE
Fix compilation error with Gettext v1.4

### DIFF
--- a/lib/ex_admin/paginate.ex
+++ b/lib/ex_admin/paginate.ex
@@ -55,7 +55,7 @@ defmodule ExAdmin.Paginate do
 
   def pagination_information(name, total) do
     markup do
-      text gettext "Displaying" <> " "
+      text (gettext "Displaying") <> " "
       b (gettext "all %{total}", total: total)
       text " #{name}"
     end


### PR DESCRIPTION
Fix issue report in #425. There are still some errors regarding to "translation is missing plural form 2" in the background, but the compilation is now passing through.