### PR TITLE
Register resource also can custom menu url

### DIFF
--- a/lib/ex_admin/navigation.ex
+++ b/lib/ex_admin/navigation.ex
@@ -48,8 +48,8 @@ defmodule ExAdmin.Navigation do
 
   def nav_link(conn, %{controller: controller, resource_model: resource_model} = registered, opts) do
     controller_name = controller_name(controller)
-    path = admin_resource_path(resource_model, :index)
     menu = Map.get(registered, :menu, %{})
+    path = Map.get(menu, :url, admin_resource_path(resource_model, :index))
     name = Map.get(menu, :label, controller_name |> titleize |> Inflex.pluralize())
 
     theme_module(conn, Layout).link_to_active(


### PR DESCRIPTION
In this situation, project have two difference namespace but same name module.Like  "A.deposit", "B.deposit".
But when I register these resource, they generate the same menu url(/deposits).
So I need to custom one of them url, like "/b_deposits".
And I find now register_page have this option, so I add it into register_resource either.