### PR TITLE
Link to static content using static_path rahter than static_url

### DIFF
--- a/web/templates/layout/active_admin.html.eex
+++ b/web/templates/layout/active_admin.html.eex
@@ -10,7 +10,7 @@
     <meta name="csrf-token" id="_csrf_token" content="<%= Plug.CSRFProtection.get_csrf_token %>" />
     <%= favicon() %>
     <title><%= site_title() %></title>
-    <link rel="stylesheet" media="screen" type="text/css" href="<%= static_url(@conn, "/css/active_admin.css.css") %>">
+    <link rel="stylesheet" media="screen" type="text/css" href="<%= static_path(@conn, "/css/active_admin.css.css") %>">
 
     <!-- jQuery 2.1.4 & jquery-ui 1.11.4 -->
     <script src="<%= static_url(@conn, "/js/jquery.min.js") %>"></script>
@@ -55,7 +55,7 @@
         </footer>
       </div>
     </body>
-    <script src='<%= static_url(@conn, "/js/ex_admin_common.js") %>'></script>
+    <script src='<%= static_path(@conn, "/js/ex_admin_common.js") %>'></script>
     <script type="text/javascript">
       $(function() {
         $('#theme-selector').change(function(e) {

--- a/web/templates/layout/admin_lte2.html.eex
+++ b/web/templates/layout/admin_lte2.html.eex
@@ -10,7 +10,7 @@
     <meta name="csrf-token" id="_csrf_token" content="<%= Plug.CSRFProtection.get_csrf_token %>" />
     <%= favicon() %>
     <title><%= site_title() %></title>
-    <link rel="stylesheet" href="<%= static_url(@conn, "/css/admin_lte2.css") %>">
+    <link rel="stylesheet" href="<%= static_path(@conn, "/css/admin_lte2.css") %>">
     <!-- Ionicons -->
     <%# <link rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css"> %>
     <!-- Theme style -->
@@ -69,8 +69,8 @@
       $.widget.bridge('uibutton', $.ui.button);
     </script>
     <!-- Bootstrap 3.3.5 -->
-    <script src='<%= static_url(@conn, "/js/ex_admin_common.js") %>'></script>
-    <script src='<%= static_url(@conn, "/js/admin_lte2.js") %>'></script>
+    <script src='<%= static_path(@conn, "/js/ex_admin_common.js") %>'></script>
+    <script src='<%= static_path(@conn, "/js/admin_lte2.js") %>'></script>
   </body>
   <script type="text/javascript">
     $(function() {


### PR DESCRIPTION
I'm developing an application that responds to requests on multiple host names having several different subdomain names under the same main (second-level) domain (for example `customer-a.example.org`, `customer-b.example.org`, `customer-c.example.org`). The setup is described in this blog post: https://blog.gazler.com/blog/2015/07/18/subdomains-with-phoenix/. However, the application does not respond to requests on the main (second-level) domain name (in this example: `example.org`).

Since ExAdmin links to static resources (JavaScript and CSS) used by the templates `active_admin.html.eex` and `admin_lte2.html.eex` by using the function `static_url`, these resources fail to load in my application. The generated links don't include the subdomain name, like this: 

https://example.org/css/admin_lte2-4b903242aada0f319f0e076944273dfc.css?vsn=d
https://example.org/js/jquery.min-cfb4c11ee8b6c29969a2a615604d49f9.js?vsn=d

Is there a reason why `static_url` is used rather than `static_path`? This PR suggests switching to using `static_path` which would be really helpful for applications using subdomains in this way.
