### PR TITLE
allow customize log level controller ex_admin

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,8 @@ use Mix.Config
 #   logout_user: nil,
 #   modules: [
 #     Nested.ExAdmin.Dashboard,
-#   ]
+#   ],
+#   log_level: :debug
 config :ex_admin,
   repo: MyProject.Repo,
   module: MyProject,

--- a/web/web.ex
+++ b/web/web.ex
@@ -13,7 +13,7 @@ defmodule ExAdmin.Web do
 
   def controller do
     quote do
-      use Phoenix.Controller
+      use Phoenix.Controller, log: Application.get_env(:ex_admin, :log_level, :debug)
 
       import Ecto.Schema
       import Ecto.Query, only: [from: 1, from: 2]


### PR DESCRIPTION
Hi, I would like to merge this in order to allow the community to chose the log level for controllers as its possible for Phoenix Web Controller.

```
[info] Processing with ExAdmin.AdminController.dashboard/2
  Parameters: %{}
  Pipelines: [:protected]
```